### PR TITLE
Fixes en registro de jugadores

### DIFF
--- a/dist/game/config/EventEngine/Language/lang_en.xml
+++ b/dist/game/config/EventEngine/Language/lang_en.xml
@@ -7,7 +7,8 @@
 	<!-- Events -->
 	<message id="event_aborted" text="The event has been aborted due to lack of participants."/>
 	<message id="event_registration_on" text="registration for event engine has been opened! Register now!" />
-	<message id="event_registration_notRegState" text="the event is no in the registration state, you cannot register now. Try the spectator mode, go!" />
+	<message id="event_registration_notRegState" text="the event is not in the registration state, you cannot register now. Try the spectator mode, go!" />
+	<message id="event_registration_notUnRegState" text="the event is not in the registration state, you cannot unregister now." />
 	<message id="event_vote_notVoteState" text="the event is no in the vote state, you cannot vote now." />
 	
 	<message id="event_login_participate" text="Come on! And participate!" />

--- a/java/net/sf/eventengine/EventEngineManager.java
+++ b/java/net/sf/eventengine/EventEngineManager.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
@@ -505,15 +506,44 @@ public class EventEngineManager
 	// XXX PLAYERS REGISTER -----------------------------------------------------------------------------
 	
 	// Lista de players en el evento.
-	private static final Map<Integer, L2PcInstance> _eventRegisterPlayers = new ConcurrentHashMap<>();
+	private static final Set<L2PcInstance> EVENT_REGISTERED_PLAYERS = ConcurrentHashMap.newKeySet();
 	
 	/**
-	 * Obetenemos la lista completa de todos los players registrados en el evento.<br>
-	 * @return Collection<PlayerHolder>
+	 * Obtenemos la colección de jugadores registrados
+	 * @return Collection<L2PcInstance>
 	 */
-	public static Collection<L2PcInstance> getAllRegisterPlayers()
+	public static Collection<L2PcInstance> getAllRegisteredPlayers()
 	{
-		return _eventRegisterPlayers.values();
+		return EVENT_REGISTERED_PLAYERS;
+	}
+	
+	/**
+	 * Limpia la colección de jugadores
+	 * @return
+	 */
+	public static void clearRegisteredPlayers()
+	{
+		EVENT_REGISTERED_PLAYERS.clear();
+	}
+	
+	/**
+	 * Obtenemos si la cantidad de jugadores registrados es 0
+	 * @return <li>True - > no hay jugadores registrados.</li><br>
+	 *         <li>False - > hay al menos un jugador registrado.</li><br>
+	 */
+	public static boolean isEmptyRegisteredPlayers()
+	{
+		return EVENT_REGISTERED_PLAYERS.isEmpty();
+	}
+	
+	/**
+	 * Obtenemos si el jugador se encuentra registrado
+	 * @return <li>True - > Está registrado.</li><br>
+	 *         <li>False - > No está registrado.</li><br>
+	 */
+	public static boolean isRegistered(L2PcInstance player)
+	{
+		return EVENT_REGISTERED_PLAYERS.contains(player);
 	}
 	
 	/**
@@ -524,14 +554,7 @@ public class EventEngineManager
 	 */
 	public static boolean registerPlayer(L2PcInstance player)
 	{
-		if (_eventRegisterPlayers.containsKey(player.getObjectId()))
-		{
-			return false;
-		}
-		
-		_eventRegisterPlayers.put(player.getObjectId(), player);
-		
-		return true;
+		return EVENT_REGISTERED_PLAYERS.add(player);
 	}
 	
 	/**
@@ -542,19 +565,7 @@ public class EventEngineManager
 	 */
 	public static boolean unRegisterPlayer(L2PcInstance player)
 	{
-		if (!isOpenRegister())
-		{
-			return false;
-		}
-		
-		if (!_eventRegisterPlayers.containsKey(player.getObjectId()))
-		{
-			return false;
-		}
-		
-		_eventRegisterPlayers.remove(player.getObjectId());
-		
-		return true;
+		return EVENT_REGISTERED_PLAYERS.remove(player);
 	}
 	
 	// XXX MISC ---------------------------------------------------------------------------------------

--- a/java/net/sf/eventengine/ai/NpcManager.java
+++ b/java/net/sf/eventengine/ai/NpcManager.java
@@ -289,17 +289,24 @@ public class NpcManager extends Quest
 				}
 				
 			case "unregister":
-				if (EventEngineManager.unRegisterPlayer(player))
+				if (EventEngineManager.isOpenRegister())
 				{
-					player.sendMessage(MsgHandler.getTag() + MsgHandler.getMsg("unregistering_notRegistered"));
-					return index(player);
+					if (EventEngineManager.unRegisterPlayer(player))
+					{
+						player.sendMessage(MsgHandler.getTag() + MsgHandler.getMsg("unregistering_unregistered"));
+						return index(player);
+					}
+					else
+					{
+						player.sendMessage(MsgHandler.getTag() + MsgHandler.getMsg("unregistering_notRegistered"));
+						return index(player);
+					}
 				}
 				else
 				{
-					player.sendMessage(MsgHandler.getTag() + MsgHandler.getMsg("unregistering_unregistered"));
+					player.sendMessage(MsgHandler.getTag() + MsgHandler.getMsg("event_registration_notUnRegState"));
 					return index(player);
 				}
-				
 				// Multi-Language System menu
 			case "menulang":
 				html.setFile(player.getHtmlPrefix(), "data/html/events/event_lang.htm");
@@ -359,7 +366,7 @@ public class NpcManager extends Quest
 		if (EventEngineManager.isOpenRegister())
 		{
 			html.replace("%menuInfo%", MsgHandler.getMsg("event_registration_on"));
-			if (EventEngineManager.getAllRegisterPlayers().contains(player.getObjectId()))
+			if (EventEngineManager.isRegistered(player))
 			{
 				html.replace("%buttonActionName%", MsgHandler.getMsg("button_unregister"));
 				html.replace("%buttonAction%", "bypass -h Quest " + NpcManager.class.getSimpleName() + " unregister");

--- a/java/net/sf/eventengine/events/OneVsOne.java
+++ b/java/net/sf/eventengine/events/OneVsOne.java
@@ -134,7 +134,7 @@ public class OneVsOne extends AbstractEvent
 	 */
 	private void createTeams()
 	{
-		if (EventEngineManager.getAllRegisterPlayers().isEmpty())
+		if (EventEngineManager.isEmptyRegisteredPlayers())
 		{
 			return;
 		}

--- a/java/net/sf/eventengine/events/TeamVsTeam.java
+++ b/java/net/sf/eventengine/events/TeamVsTeam.java
@@ -179,7 +179,7 @@ public class TeamVsTeam extends AbstractEvent
 	 */
 	private void giveRewardsTeams()
 	{
-		if (EventEngineManager.getAllRegisterPlayers().isEmpty())
+		if (EventEngineManager.isEmptyRegisteredPlayers())
 		{
 			return;
 		}

--- a/java/net/sf/eventengine/handler/AbstractEvent.java
+++ b/java/net/sf/eventengine/handler/AbstractEvent.java
@@ -235,13 +235,13 @@ public abstract class AbstractEvent
 	 */
 	private void createEventPlayers()
 	{
-		for (L2PcInstance player : EventEngineManager.getAllRegisterPlayers())
+		for (L2PcInstance player : EventEngineManager.getAllRegisteredPlayers())
 		{
 			_eventPlayers.put(player.getObjectId(), new PlayerHolder(player));
 		}
 		
 		// Limpiamos la lista, ya no la necesitaremos.
-		EventEngineManager.getAllRegisterPlayers().clear();
+		EventEngineManager.clearRegisteredPlayers();
 	}
 	
 	/**

--- a/java/net/sf/eventengine/task/EventEngineTask.java
+++ b/java/net/sf/eventengine/task/EventEngineTask.java
@@ -83,7 +83,7 @@ public class EventEngineTask implements Runnable
 			}
 			case RUN_EVENT:
 			{
-				if (EventEngineManager.getAllRegisterPlayers().isEmpty())
+				if (EventEngineManager.isEmptyRegisteredPlayers())
 				{
 					// Tiempo para el proximo evento en minutos.
 					EventEngineManager.setTime(Configs.EVENT_TASK * 60);


### PR DESCRIPTION
## Summary

-Se cambia un mapa en EventEngineManager por una colección concurrente y que no permite elementos repetidos (los métodos quedan más simples). No tiene sentido tener un mapa con una key que se consigue con el valor.
-Fixes en el NpcManager: permite desregistrarse.
