### PR TITLE
A lot changes and reworks

### DIFF
--- a/Diff_DataPack.txt
+++ b/Diff_DataPack.txt
@@ -42,19 +42,3 @@ index 94fe9c4..5b80dc8 100644
  						if (npc.hasListener(EventType.ON_NPC_QUEST_START))
  						{
  							activeChar.setLastQuestNpcObject(npc.getObjectId());
-diff --git a/L2J_DataPack/dist/game/data/stats/npcs/custom/custom.xml b/L2J_DataPack/dist/game/data/stats/npcs/custom/custom.xml
-index 18f8f27..bda47fa 100644
---- a/L2J_DataPack/dist/game/data/stats/npcs/custom/custom.xml
-+++ b/L2J_DataPack/dist/game/data/stats/npcs/custom/custom.xml
-@@ -58,4 +58,10 @@
- 			<height normal="22.25" />
- 		</collision>
- 	</npc>
-+		<npc id="36600" displayId="32226" name="EventEngine" usingServerSideName="true" title="L2J" usingServerSideTitle="true" type="L2Npc">
-+		<collision>
-+			<radius normal="11" />
-+			<height normal="22.25" />
-+		</collision>
-+	</npc>
- </list>
-\ No newline at end of file

--- a/Diff_Server.txt
+++ b/Diff_Server.txt
@@ -1,5 +1,5 @@
 diff --git a/L2J_Server/.classpath b/L2J_Server/.classpath
-index 05e3150..0057726 100644
+index 05e3150..0b47f01 100644
 --- a/L2J_Server/.classpath
 +++ b/L2J_Server/.classpath
 @@ -1,13 +1,14 @@
@@ -18,7 +18,7 @@ index 05e3150..0057726 100644
 -</classpath>
 \ No newline at end of file
 +	<classpathentry kind="src" path="java"/>
-+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
++	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/jdk1.8.0_45"/>
 +	<classpathentry kind="lib" path="dist/libs/c3p0-0.9.5.jar"/>
 +	<classpathentry kind="lib" path="dist/libs/jython.jar"/>
 +	<classpathentry kind="lib" path="dist/libs/jython-engine-2.2.1.jar"/>
@@ -31,7 +31,7 @@ index 05e3150..0057726 100644
 +</classpath>
 diff --git a/L2J_Server/dist/libs/L2J_EventEngine.jar b/L2J_Server/dist/libs/L2J_EventEngine.jar
 new file mode 100644
-index 0000000..b8ab609
+index 0000000..223838b
 --- /dev/null
 +++ b/L2J_Server/dist/libs/L2J_EventEngine.jar
 Binary files differ
@@ -87,7 +87,7 @@ index 9bb51e3..ddbc2e1 100644
  		if ((returnBack != null) && returnBack.terminate())
  		{
 diff --git a/L2J_Server/java/com/l2jserver/gameserver/model/actor/L2Playable.java b/L2J_Server/java/com/l2jserver/gameserver/model/actor/L2Playable.java
-index cbe50df..74069b8 100644
+index cbe50df..12fc0f3 100644
 --- a/L2J_Server/java/com/l2jserver/gameserver/model/actor/L2Playable.java
 +++ b/L2J_Server/java/com/l2jserver/gameserver/model/actor/L2Playable.java
 @@ -18,6 +18,8 @@
@@ -99,7 +99,7 @@ index cbe50df..74069b8 100644
  import com.l2jserver.gameserver.ai.CtrlEvent;
  import com.l2jserver.gameserver.enums.InstanceType;
  import com.l2jserver.gameserver.instancemanager.InstanceManager;
-@@ -106,6 +108,28 @@
+@@ -106,8 +108,36 @@
  	}
  	
  	@Override
@@ -127,7 +127,15 @@ index cbe50df..74069b8 100644
 +	@Override
  	public boolean doDie(L2Character killer)
  	{
++		// L2J EventEngine
++		if ((killer != null) && killer.isPlayable())
++		{
++			EventEngineManager.getInstance().listenerOnKill((L2Playable) killer, this);
++		}
++		
  		final TerminateReturn returnBack = EventDispatcher.getInstance().notifyEvent(new OnCreatureKill(killer, this), this, TerminateReturn.class);
+ 		if ((returnBack != null) && returnBack.terminate())
+ 		{
 diff --git a/L2J_Server/java/com/l2jserver/gameserver/model/actor/instance/L2PcInstance.java b/L2J_Server/java/com/l2jserver/gameserver/model/actor/instance/L2PcInstance.java
 index ebe0026..30bc90d 100644
 --- a/L2J_Server/java/com/l2jserver/gameserver/model/actor/instance/L2PcInstance.java

--- a/dist/game/config/EventEngine/AllVsAll.properties
+++ b/dist/game/config/EventEngine/AllVsAll.properties
@@ -7,17 +7,17 @@
 
 # Enable/Disable AvA Event
 # Default: True
-AvAEventEnabled = True
+EventEnabled = True
+
+# Name of the instance file for events
+# Default: EventEngine.xml
+EventInstanceFile = EventEngine.xml
 
 # Reward for winning player
 # Example: AvAEventReward = itemId,amount;itemId,amount;itemId,amount
-AvAEventReward =  57,10000;
-
-# Reward for kill player
-# Example: AvAEventRewardKill = itemId,amount;itemId,amount;itemId,amount
-AvAEventRewardKill = 57,100;
+EventReward =  57,10000;
 
 # Player spawn, Start/Death x,y,z location
 # Format: x,y,z
 # Example: 148695,46725,-3414
-AvAEventCoordinates = 149474,46745,-3408
+EventCoordinates = 148695,46725,-3414

--- a/dist/game/config/EventEngine/CaptureTheFlag.properties
+++ b/dist/game/config/EventEngine/CaptureTheFlag.properties
@@ -1,36 +1,36 @@
 # ================================================================
-# CONFIGURATION FOR EVENT SURVIVE
+# CONFIGURATION FOR EVENT CAPTURE THE FLAG
 # ================================================================
 # Commands assigned to the configuration of the events
 # More information: L2J_EventEngine Web/Forum
 # ================================================================
 
-# Enable/Disable SV Event
-# Default: False
-EventEnabled = False
+# Enable/Disable CTF Event
+# Default: True
+EventEnabled = True
 
 # Name of the instance file for events
 # Default: EventEngine.xml
 EventInstanceFile = EventEngine.xml
 
 # Reward for winning player
-# Example: SVEventReward = itemId,amount;itemId,amount;itemId,amount
+# Example: TvTEventReward = itemId,amount;itemId,amount;itemId,amount
 EventReward =  57,10000;
 
-# Player spawn, Start/Death x,y,z location
+# First Team - Name, Start/Death x,y,z location
 # Format: x,y,z
 # Example: 148695,46725,-3414
-EventCoordinatesPlayer = 148695,46725,-3414
+EventTeam1Coordinates = 148695,46725,-3414
 
-# Mobs spawn, Start/Death x,y,z location
+# Second Team - Name, Start/Death x,y,z location
 # Format: x,y,z
 # Example: 149999,46728,-3414
-EventCoordinatesMobs = 149999,46728,-3414
+EventTeam2Coordinates = 149999,46728,-3414
 
-# ID of mobs to spawn
-# Default: 333800,333801
-EventMobsID = 22839,22840
+# Points to conquer the flag
+# Default: 10
+EventPointsConquerFlag = 10
 
-# Number of mobs to increase by round
-# Default: 5
-EventMobsSpawnForStage = 5
+# Points to kill players
+# Default: 1
+EventPointsKill = 1

--- a/dist/game/config/EventEngine/EventEngine.properties
+++ b/dist/game/config/EventEngine/EventEngine.properties
@@ -9,10 +9,6 @@
 # Default: 36600
 EventParticipationNpcId = 36600
 
-# Name of the instance file for events
-# Default: EventEngine.xml
-EventInstanceFile = EventEngine.xml
-
 # Interval time between events (minutes)
 # Default: 10
 EventInterval = 10

--- a/dist/game/config/EventEngine/Language/lang_en.xml
+++ b/dist/game/config/EventEngine/Language/lang_en.xml
@@ -64,6 +64,8 @@
 	<message id="text_configuration" text="Configurations" />
 	<message id="text_time_event" text="Time Event" />
 	<message id="revive_in" text="You will be revived within %time% seconds." />
+	<message id="team_winner" text="The team winner is the %holder%"/>
+	<message id="teams_tie" text="Tie"/>
 	
 	<!-- HTML: Lang Setting -->
 	<message id="lang_menu_title" text="Menu Setting"/>
@@ -101,5 +103,13 @@
 	<message id="buff_description" text="Select from the list 5 buff skills to start with them at the next event."/>
 	<message id="buff_text_count" text="Get Buff:"/>
 	<message id="buff_text_max" text="Max Buff:"/>
+	
+	<!-- Capture the flag -->
+	<message id="ctf_captured_the_flag" text="The %holder% team just take the enemy flag"/>
+	<message id="ctf_conquered_the_flag" text="The %holder% team conquered the enemy flag"/>
+	<message id="player_dropped_flag" text="The player %holder% has dropped the %flag% flag"/>
+	
+	<!-- All vs All -->
+	<message id="ava_first_place" text="First place: %holder%"/>
 
 </localization>

--- a/dist/game/config/EventEngine/OneVsOne.properties
+++ b/dist/game/config/EventEngine/OneVsOne.properties
@@ -7,22 +7,22 @@
 
 # Enable/Disable OvO Event
 # Default: False
-OvOEventEnabled = False
+EventEnabled = False
+
+# Name of the instance file for events
+# Default: EventEngine.xml
+EventInstanceFile = EventEngine.xml
 
 # Reward for winning player
 # Example: OvOEventReward = itemId,amount;itemId,amount;itemId,amount
-OvOEventReward =  57,10000;
-
-# Reward for kill player
-# Example: AvAEventRewardKill = itemId,amount;itemId,amount;itemId,amount
-OvOEventRewardKill = 57,100;
+EventReward =  57,10000;
 
 # First Team - Name, Start/Death x,y,z location
 # Format: x,y,z
 # Example: 148695,46725,-3414
-OvOEventTeam1Coordinates = 148695,46725,-3414
+EventTeam1Coordinates = 148695,46725,-3414
 
 # Second Team - Name, Start/Death x,y,z location
 # Format: x,y,z
 # Example: 149999,46728,-3414
-OvOEventTeam2Coordinates = 149999,46728,-3414
+EventTeam2Coordinates = 149999,46728,-3414

--- a/dist/game/config/EventEngine/TeamVsTeam.properties
+++ b/dist/game/config/EventEngine/TeamVsTeam.properties
@@ -7,22 +7,22 @@
 
 # Enable/Disable TvT Event
 # Default: True
-TvTEventEnabled = True
+EventEnabled = True
+
+# Name of the instance file for events
+# Default: EventEngine.xml
+EventInstanceFile = EventEngine.xml
 
 # Reward for winning player
 # Example: TvTEventReward = itemId,amount;itemId,amount;itemId,amount
-TvTEventReward =  57,10000;
-
-# Reward for kill player
-# Example: TvTEventRewardKill = itemId,amount;itemId,amount;itemId,amount
-TvTEventRewardKill = 57,100;
+EventReward =  57,10000;
 
 # First Team - Name, Start/Death x,y,z location
 # Format: x,y,z
 # Example: 148695,46725,-3414
-TvTEventTeam1Coordinates = 148695,46725,-3414
+EventTeam1Coordinates = 148695,46725,-3414
 
 # Second Team - Name, Start/Death x,y,z location
 # Format: x,y,z
 # Example: 149999,46728,-3414
-TvTEventTeam2Coordinates = 149999,46728,-3414
+EventTeam2Coordinates = 149999,46728,-3414

--- a/dist/game/data/stats/npcs/custom/EventEngineNpc.xml
+++ b/dist/game/data/stats/npcs/custom/EventEngineNpc.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/npcs.xsd">
+	<npc id="36600" displayId="32226" name="EventEngine" usingServerSideName="true" title="L2J" usingServerSideTitle="true" type="L2Npc">
+		<collision>
+			<radius normal="11" />
+			<height normal="22.25" />
+		</collision>
+	</npc>
+	<npc id="36601" displayId="35062" name="Flag" usingServerSideName="true" title="BLUE" usingServerSideTitle="true" type="L2Npc">
+		<collision>
+			<radius normal="11" />
+			<height normal="22.25" />
+		</collision>
+	</npc>
+	<npc id="36602" displayId="35062" name="Flag" usingServerSideName="true" title="RED" usingServerSideTitle="true" type="L2Npc">
+		<collision>
+			<radius normal="11" />
+			<height normal="22.25" />
+		</collision>
+	</npc>
+	<npc id="36603" displayId="32027" name="Holder" usingServerSideName="true" title="BLUE" usingServerSideTitle="true" type="L2Npc">
+		<collision>
+			<radius normal="11" />
+			<height normal="22.25" />
+		</collision>
+	</npc>
+	<npc id="36604" displayId="32027" name="Holder" usingServerSideName="true" title="RED" usingServerSideTitle="true" type="L2Npc">
+		<collision>
+			<radius normal="11" />
+			<height normal="22.25" />
+		</collision>
+	</npc>
+</list>

--- a/java/net/sf/eventengine/EventEngineManager.java
+++ b/java/net/sf/eventengine/EventEngineManager.java
@@ -42,9 +42,7 @@ import com.l2jserver.gameserver.instancemanager.InstanceManager;
 import com.l2jserver.gameserver.model.actor.L2Character;
 import com.l2jserver.gameserver.model.actor.L2Npc;
 import com.l2jserver.gameserver.model.actor.L2Playable;
-import com.l2jserver.gameserver.model.actor.instance.L2DoorInstance;
 import com.l2jserver.gameserver.model.actor.instance.L2PcInstance;
-import com.l2jserver.gameserver.model.instancezone.InstanceWorld;
 import com.l2jserver.gameserver.model.items.L2Item;
 import com.l2jserver.gameserver.model.skills.Skill;
 import com.l2jserver.gameserver.network.clientpackets.Say2;
@@ -115,51 +113,6 @@ public class EventEngineManager
 	public void decreaseTime()
 	{
 		_time--;
-	}
-	
-	// XXX DINAMIC INSTANCE ------------------------------------------------------------------------------
-	private final List<InstanceWorld> _instanceWorld = new ArrayList<>();
-	
-	/**
-	 * Creamos instancias dinamicas y un mundo para ella
-	 * @param count
-	 * @return InstanceWorld: world creado para la instancia
-	 */
-	public InstanceWorld createNewInstanceWorld()
-	{
-		InstanceWorld world = null;
-		try
-		{
-			int instanceId = InstanceManager.getInstance().createDynamicInstance(ConfigData.getInstance().INSTANCE_FILE);
-			InstanceManager.getInstance().getInstance(instanceId).setAllowSummon(false);
-			InstanceManager.getInstance().getInstance(instanceId).setPvPInstance(true);
-			InstanceManager.getInstance().getInstance(instanceId).setEmptyDestroyTime(1000 + 60000L);
-			// Cerramos las puertas de la instancia si es q existen
-			for (L2DoorInstance door : InstanceManager.getInstance().getInstance(instanceId).getDoors())
-			{
-				door.closeMe();
-			}
-			
-			world = new EventEngineWorld();
-			world.setInstanceId(instanceId);
-			world.setTemplateId(100); // TODO hardcode
-			world.setStatus(0);
-			InstanceManager.getInstance().addWorld(world);
-			_instanceWorld.add(world);
-			
-		}
-		catch (Exception e)
-		{
-			LOGGER.warning(EventEngineManager.class.getSimpleName() + ": -> createDynamicInstances() " + e);
-			e.printStackTrace();
-		}
-		
-		return world;
-	}
-	
-	public List<InstanceWorld> getInstancesWorlds()
-	{
-		return _instanceWorld;
 	}
 	
 	// XXX NEXT EVENT ---------------------------------------------------------------------------------
@@ -648,7 +601,6 @@ public class EventEngineManager
 		setCurrentEvent(null);
 		clearVotes();
 		clearRegisteredPlayers();
-		getInstancesWorlds().clear();
 	}
 	
 	/**

--- a/java/net/sf/eventengine/datatables/ConfigData.java
+++ b/java/net/sf/eventengine/datatables/ConfigData.java
@@ -27,7 +27,7 @@ import com.l2jserver.gameserver.model.Location;
 import com.l2jserver.gameserver.model.holders.ItemHolder;
 
 /**
- * Clase encargada de leer todos los configs establecidos en los archivos de tipo "properties"
+ * Load the config from "properties"
  * @author fissban
  */
 public class ConfigData
@@ -35,68 +35,66 @@ public class ConfigData
 	private static final String EVENT_CONFIG = "./config/EventEngine/EventEngine.properties";
 	private static final String TVT_CONFIG = "./config/EventEngine/TeamVsTeam.properties";
 	private static final String AVA_CONFIG = "./config/EventEngine/AllVsAll.properties";
-	// private static final String CTF_CONFIG = "./config/EventEngine/CTF.properties";
+	private static final String CTF_CONFIG = "./config/EventEngine/CaptureTheFlag.properties";
 	private static final String OVO_CONFIG = "./config/EventEngine/OneVsOne.properties";
 	private static final String SURVIVE_CONFIG = "./config/EventEngine/Survive.properties";
 	
-	// lista de configs generales
-	
-	/** Definimos ID del npc del engine */
+	// General configs
 	public int NPC_MANAGER_ID;
-	/** Definimos el xml q usaremos para nuestras instancias. */
-	public String INSTANCE_FILE;
-	/** Definimos cada cuanto se ejecutara algun evento en hs */
 	public int EVENT_TASK;
-	/** Definimos si va a haber tiempo de votacion */
 	public boolean EVENT_VOTING_ENABLED;
-	/** Definimos el tiempo que durara el periodo de votacion */
 	public int EVENT_VOTING_TIME;
-	/** Definimos el tiempo que durara el periodo de registro */
 	public int EVENT_REGISTER_TIME;
-	/** Definimos el tiempo que durara cada evento en minutos */
 	public int EVENT_DURATION;
-	/** Definimos si permitimos o no el daño entre amigos. */
 	public boolean FRIENDLY_FIRE;
-	/** Definimos la cant de players maximo/minimo que podran participar */
 	public int MIN_PLAYERS_IN_EVENT;
 	public int MAX_PLAYERS_IN_EVENT;
-	/** Definimos el lvl maximo/minimo que podran participar de los eventos. */
 	public int MIN_LVL_IN_EVENT;
 	public int MAX_LVL_IN_EVENT;
-	/** Definimos la cantidad maxima de buffs q se podran usar */
 	public static int MAX_BUFF_COUNT;
+	
+	// -------------------------------------------------------------------------------
+	// Configs Capture The Flag
+	// -------------------------------------------------------------------------------
+	public boolean CTF_EVENT_ENABLED;
+	public String CTF_INSTANCE_FILE;
+	public List<ItemHolder> CTF_REWARD_PLAYER_WIN = new ArrayList<>();
+	public Location CTF_COORDINATES_TEAM_RED;
+	public Location CTF_COORDINATES_TEAM_BLUE;
+	public int CTF_POINTS_CONQUER_FLAG;
+	public int CTF_POINTS_KILL;
 	
 	// -------------------------------------------------------------------------------
 	// Configs All Vs All
 	// -------------------------------------------------------------------------------
 	public boolean AVA_EVENT_ENABLED;
+	public String AVA_INSTANCE_FILE;
 	public List<ItemHolder> AVA_REWARD_PLAYER_WIN = new ArrayList<>();
-	public List<ItemHolder> AVA_REWARD_KILL_PLAYER = new ArrayList<>();
 	public Location AVA_COORDINATES_PLAYER;
 	
 	// -------------------------------------------------------------------------------
 	// Configs One Vs One
 	// -------------------------------------------------------------------------------
 	public boolean OVO_EVENT_ENABLED;
-	public boolean OVO_REWARD_TEAM_TIE;
+	public String OVO_INSTANCE_FILE;
 	public List<ItemHolder> OVO_REWARD_PLAYER_WIN = new ArrayList<>();
-	public List<ItemHolder> OVO_REWARD_KILL_PLAYER = new ArrayList<>();
-	public Location OVO_COORDINATES_TEAM_1;
-	public Location OVO_COORDINATES_TEAM_2;
+	public Location OVO_COORDINATES_TEAM_RED;
+	public Location OVO_COORDINATES_TEAM_BLUE;
 	
 	// -------------------------------------------------------------------------------
 	// Configs Team Vs Team
 	// -------------------------------------------------------------------------------
+	public String TVT_INSTANCE_FILE;
 	public boolean TVT_EVENT_ENABLED;
 	public List<ItemHolder> TVT_REWARD_PLAYER_WIN = new ArrayList<>();
-	public List<ItemHolder> TVT_REWARD_KILL_PLAYER = new ArrayList<>();
-	public Location TVT_COORDINATES_TEAM_1;
-	public Location TVT_COORDINATES_TEAM_2;
+	public Location TVT_COORDINATES_TEAM_RED;
+	public Location TVT_COORDINATES_TEAM_BLUE;
 	
 	// -------------------------------------------------------------------------------
 	// Configs Survive
 	// -------------------------------------------------------------------------------
 	public boolean SURVIVE_EVENT_ENABLED;
+	public String SURVIVE_INSTANCE_FILE;
 	public List<ItemHolder> SURVIVE_REWARD_PLAYER_WIN = new ArrayList<>();
 	public Location SURVIVE_COORDINATES_PLAYER;
 	public Location SURVIVE_COORDINATES_MOBS;
@@ -108,7 +106,6 @@ public class ConfigData
 		load();
 	}
 	
-	// Metodo encargado de leer los configs
 	public void load()
 	{
 		EventPropertiesParser settings;
@@ -127,48 +124,60 @@ public class ConfigData
 		MAX_PLAYERS_IN_EVENT = settings.getInt("EventMaxPlayers", 20);
 		MIN_LVL_IN_EVENT = settings.getInt("EventMinPlayerLevel", 40);
 		MAX_LVL_IN_EVENT = settings.getInt("EventMaxPlayerLevel", 78);
-		INSTANCE_FILE = settings.getString("EventInstanceFile", "EventEngine.xml");
 		MAX_BUFF_COUNT = settings.getInt("EventMaxBuffCount", 5);
+		
+		// ------------------------------------------------------------------------------------- //
+		// CaptureTheFlag.properties
+		// ------------------------------------------------------------------------------------- //
+		settings = new EventPropertiesParser(CTF_CONFIG);
+		CTF_INSTANCE_FILE = settings.getString("EventInstanceFile", "EventEngine.xml");
+		CTF_EVENT_ENABLED = settings.getBoolean("EventEnabled", false);
+		CTF_REWARD_PLAYER_WIN = settings.getItemHolderList("EventReward");
+		CTF_COORDINATES_TEAM_RED = settings.getLocation("EventTeam1Coordinates");
+		CTF_COORDINATES_TEAM_BLUE = settings.getLocation("EventTeam2Coordinates");
+		CTF_POINTS_CONQUER_FLAG = settings.getInt("EventPointsConquerFlag", 10);
+		CTF_POINTS_KILL = settings.getInt("EventPointsKill", 1);
 		
 		// ------------------------------------------------------------------------------------- //
 		// AllVsAll.properties
 		// ------------------------------------------------------------------------------------- //
 		settings = new EventPropertiesParser(AVA_CONFIG);
-		AVA_EVENT_ENABLED = settings.getBoolean("AvAEventEnabled", false);
-		AVA_REWARD_PLAYER_WIN = settings.getItemHolderList("AvAEventReward");
-		AVA_REWARD_KILL_PLAYER = settings.getItemHolderList("AvAEventRewardKill");
-		AVA_COORDINATES_PLAYER = settings.getLocation("AvAEventCoordinates");
+		AVA_INSTANCE_FILE = settings.getString("EventInstanceFile", "EventEngine.xml");
+		AVA_EVENT_ENABLED = settings.getBoolean("EventEnabled", false);
+		AVA_REWARD_PLAYER_WIN = settings.getItemHolderList("EventReward");
+		AVA_COORDINATES_PLAYER = settings.getLocation("EventCoordinates");
 		
 		// ------------------------------------------------------------------------------------- //
 		// OneVsOne.properties
 		// ------------------------------------------------------------------------------------- //
 		settings = new EventPropertiesParser(OVO_CONFIG);
-		OVO_EVENT_ENABLED = settings.getBoolean("OvOEventEnabled", false);
-		OVO_REWARD_PLAYER_WIN = settings.getItemHolderList("OvOEventReward");
-		OVO_REWARD_KILL_PLAYER = settings.getItemHolderList("OvOEventRewardKill");
-		OVO_COORDINATES_TEAM_1 = settings.getLocation("OvOEventTeam1Coordinates");
-		OVO_COORDINATES_TEAM_2 = settings.getLocation("OvOEventTeam2Coordinates");
+		OVO_INSTANCE_FILE = settings.getString("EventInstanceFile", "EventEngine.xml");
+		OVO_EVENT_ENABLED = settings.getBoolean("EventEnabled", false);
+		OVO_REWARD_PLAYER_WIN = settings.getItemHolderList("EventReward");
+		OVO_COORDINATES_TEAM_RED = settings.getLocation("EventTeam1Coordinates");
+		OVO_COORDINATES_TEAM_BLUE = settings.getLocation("EventTeam2Coordinates");
 		
 		// ------------------------------------------------------------------------------------- //
 		// TeamVsTeam.properties
 		// ------------------------------------------------------------------------------------- //
 		settings = new EventPropertiesParser(TVT_CONFIG);
-		TVT_EVENT_ENABLED = settings.getBoolean("TvTEventEnabled", false);
-		TVT_REWARD_PLAYER_WIN = settings.getItemHolderList("TvTEventReward");
-		TVT_REWARD_KILL_PLAYER = settings.getItemHolderList("TvTEventRewardKill");
-		TVT_COORDINATES_TEAM_1 = settings.getLocation("TvTEventTeam1Coordinates");
-		TVT_COORDINATES_TEAM_2 = settings.getLocation("TvTEventTeam2Coordinates");
+		TVT_INSTANCE_FILE = settings.getString("EventInstanceFile", "EventEngine.xml");
+		TVT_EVENT_ENABLED = settings.getBoolean("EventEnabled", false);
+		TVT_REWARD_PLAYER_WIN = settings.getItemHolderList("EventReward");
+		TVT_COORDINATES_TEAM_RED = settings.getLocation("EventTeam1Coordinates");
+		TVT_COORDINATES_TEAM_BLUE = settings.getLocation("EventTeam2Coordinates");
 		
 		// ------------------------------------------------------------------------------------- //
 		// Survive.properties
 		// ------------------------------------------------------------------------------------- //
 		settings = new EventPropertiesParser(SURVIVE_CONFIG);
-		SURVIVE_EVENT_ENABLED = settings.getBoolean("SVEventEnabled", false);
-		SURVIVE_REWARD_PLAYER_WIN = settings.getItemHolderList("SVEventReward");
-		SURVIVE_COORDINATES_PLAYER = settings.getLocation("SVEventCoordinatesPlayer");
-		SURVIVE_COORDINATES_MOBS = settings.getLocation("SVEventCoordinatesMobs");
-		SURVIVE_MONSTERS_ID = settings.getListInteger("SVEventMobsID");
-		SURVIVE_MONSTER_SPAWN_FOR_STAGE = settings.getInt("SVEventMobsSpawnForStage", 5);
+		SURVIVE_INSTANCE_FILE = settings.getString("EventInstanceFile", "EventEngine.xml");
+		SURVIVE_EVENT_ENABLED = settings.getBoolean("EventEnabled", false);
+		SURVIVE_REWARD_PLAYER_WIN = settings.getItemHolderList("EventReward");
+		SURVIVE_COORDINATES_PLAYER = settings.getLocation("EventCoordinatesPlayer");
+		SURVIVE_COORDINATES_MOBS = settings.getLocation("EventCoordinatesMobs");
+		SURVIVE_MONSTERS_ID = settings.getListInteger("EventMobsID");
+		SURVIVE_MONSTER_SPAWN_FOR_STAGE = settings.getInt("EventMobsSpawnForStage", 5);
 	}
 	
 	public static ConfigData getInstance()

--- a/java/net/sf/eventengine/datatables/EventData.java
+++ b/java/net/sf/eventengine/datatables/EventData.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 
 import net.sf.eventengine.events.AllVsAll;
+import net.sf.eventengine.events.CaptureTheFlag;
 import net.sf.eventengine.events.OneVsOne;
 import net.sf.eventengine.events.Survive;
 import net.sf.eventengine.events.TeamVsTeam;
@@ -54,6 +55,12 @@ public class EventData
 		{
 			_eventList.add(TeamVsTeam.class);
 			_eventMap.put(TeamVsTeam.class.getSimpleName(), TeamVsTeam.class);
+		}
+		
+		if (ConfigData.getInstance().CTF_EVENT_ENABLED)
+		{
+			_eventList.add(CaptureTheFlag.class);
+			_eventMap.put(CaptureTheFlag.class.getSimpleName(), CaptureTheFlag.class);
 		}
 	}
 	

--- a/java/net/sf/eventengine/events/CaptureTheFlag.java
+++ b/java/net/sf/eventengine/events/CaptureTheFlag.java
@@ -18,29 +18,55 @@
  */
 package net.sf.eventengine.events;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import net.sf.eventengine.datatables.ConfigData;
 import net.sf.eventengine.enums.EventState;
+import net.sf.eventengine.enums.PlayerColorType;
 import net.sf.eventengine.handler.AbstractEvent;
 import net.sf.eventengine.holder.PlayerHolder;
+import net.sf.eventengine.util.EventUtil;
 
+import com.l2jserver.gameserver.datatables.ItemTable;
 import com.l2jserver.gameserver.enums.Team;
 import com.l2jserver.gameserver.model.actor.L2Character;
 import com.l2jserver.gameserver.model.actor.L2Npc;
+import com.l2jserver.gameserver.model.instancezone.InstanceWorld;
+import com.l2jserver.gameserver.model.itemcontainer.Inventory;
 import com.l2jserver.gameserver.model.items.L2Item;
+import com.l2jserver.gameserver.model.items.L2Weapon;
+import com.l2jserver.gameserver.model.items.instance.L2ItemInstance;
 import com.l2jserver.gameserver.model.skills.Skill;
+import com.l2jserver.gameserver.network.clientpackets.Say2;
 
 /**
  * @author fissban
  */
 public class CaptureTheFlag extends AbstractEvent
 {
+	// Flags
+	private static final int BLUE_FLAG = 36601;
+	private static final int RED_FLAG = 36602;
+	// Holder
+	private static final int BLUE_HOLDER = 36603;
+	private static final int RED_HOLDER = 36604;
+	// FlagItem
+	private static final int FLAG_ITEM = 6718;
+	// Points to conquer the flag
+	private final int POINTS_CONQUER_FLAG = ConfigData.getInstance().CTF_POINTS_CONQUER_FLAG;
+	private final int POINTS_KILL = ConfigData.getInstance().CTF_POINTS_KILL;
+	// Points that each team.
+	private int _pointsRed = 0;
+	private int _pointsBlue = 0;
+	
 	public CaptureTheFlag()
 	{
 		super();
-		
-		// Definimos los spawns de cada team
-		setTeamSpawn(Team.RED, ConfigData.getInstance().TVT_COORDINATES_TEAM_1);
-		setTeamSpawn(Team.BLUE, ConfigData.getInstance().TVT_COORDINATES_TEAM_2);
+		setInstanceFile(ConfigData.getInstance().CTF_INSTANCE_FILE);
+		// We define each team spawns
+		setTeamSpawn(Team.RED, ConfigData.getInstance().CTF_COORDINATES_TEAM_RED);
+		setTeamSpawn(Team.BLUE, ConfigData.getInstance().CTF_COORDINATES_TEAM_BLUE);
 	}
 	
 	@Override
@@ -49,58 +75,363 @@ public class CaptureTheFlag extends AbstractEvent
 		switch (state)
 		{
 			case START:
-				prepareToStart(); // Metodo general
-				// createTeam();
-				teleportAllPlayers();
+				prepareToStart(); // General Method
+				createTeams();
+				spawnFlagsAndHolders();
+				teleportAllPlayers(100);
 				break;
 			
 			case FIGHT:
-				prepareToFight(); // Metodo general
+				prepareToFight(); // General Method
 				break;
 			
 			case END:
-				// giveRewardsTeams();
-				prepareToEnd(); // Metodo general
+				giveRewardsTeams();
+				prepareToEnd(); // General Method
 				break;
 		}
-		
 	}
 	
 	@Override
 	public void onInteract(PlayerHolder player, L2Npc npc)
 	{
-		// TODO Auto-generated method stub
+		switch (npc.getId())
+		{
+			case BLUE_FLAG:
+				if (player.getPcInstance().getTeam() == Team.RED)
+				{
+					// We equip flag
+					equipFlag(player);
+					// We remove the flag from his position
+					removeNpc(npc);
+					// We announced that a flag was taken
+					EventUtil.announceToAllPlayersInEvent(Say2.SCREEN_ANNOUNCE, "ctf_captured_the_flag", "%holder%", Team.RED.toString());
+				}
+				break;
+			
+			case RED_FLAG:
+				if (player.getPcInstance().getTeam() == Team.BLUE)
+				{
+					// We equip flag
+					equipFlag(player);
+					// We remove the flag from his position
+					removeNpc(npc);
+					// We announced that a flag was taken
+					EventUtil.announceToAllPlayersInEvent(Say2.SCREEN_ANNOUNCE, "ctf_captured_the_flag", "%holder%", Team.BLUE.toString());
+				}
+				break;
+			
+			case BLUE_HOLDER:
+				if (player.getPcInstance().getTeam() == Team.BLUE)
+				{
+					if (hasFlag(player))
+					{
+						// We increased the points
+						_pointsBlue += POINTS_CONQUER_FLAG;
+						// Remove the flag character
+						unequiFlag(player);
+						// We created the flag again
+						addEventNpc(RED_FLAG, ConfigData.getInstance().CTF_COORDINATES_TEAM_RED, Team.RED, getInstancesWorlds().get(0).getInstanceId());
+						// We announced that a flag was taken
+						EventUtil.announceToAllPlayersInEvent(Say2.SCREEN_ANNOUNCE, "ctf_conquered_the_flag", "%holder%", Team.BLUE.toString());
+						// Show points of each team
+						showPoint();
+					}
+				}
+				break;
+			
+			case RED_HOLDER:
+				if (player.getPcInstance().getTeam() == Team.RED)
+				{
+					if (hasFlag(player))
+					{
+						// We increased the points
+						_pointsRed += POINTS_CONQUER_FLAG;
+						// Remove the flag character
+						unequiFlag(player);
+						// We created the flag again
+						addEventNpc(BLUE_FLAG, ConfigData.getInstance().CTF_COORDINATES_TEAM_BLUE, Team.BLUE, getInstancesWorlds().get(0).getInstanceId());
+						// We announced that a flag was taken
+						EventUtil.announceToAllPlayersInEvent(Say2.SCREEN_ANNOUNCE, "ctf_conquered_the_flag", "%holder%", Team.RED.toString());
+						// Show points of each team
+						showPoint();
+					}
+				}
+				break;
+		}
 	}
 	
 	@Override
 	public void onKill(PlayerHolder player, L2Character target)
 	{
-		// TODO Auto-generated method stub
+		PlayerHolder targetEvent = getEventPlayer(target);
+		
+		if (hasFlag(targetEvent))
+		{
+			// Remove the flag character
+			unequiFlag(targetEvent);
+			// Drop flag.
+			dropFlag(targetEvent);
+		}
+		
+		// We increased the team's points.
+		switch (player.getPcInstance().getTeam())
+		{
+			case RED:
+				_pointsRed += POINTS_KILL;
+				break;
+			case BLUE:
+				_pointsBlue += POINTS_KILL;
+				break;
+		}
+		
+		showPoint();
 	}
 	
 	@Override
 	public void onDeath(PlayerHolder player)
 	{
-		// TODO Auto-generated method stub
+		giveResurrectPlayer(player, 10, 100);
 	}
 	
 	@Override
 	public boolean onAttack(PlayerHolder player, L2Character target)
 	{
-		// TODO Auto-generated method stub
 		return false;
 	}
 	
 	@Override
 	public boolean onUseSkill(PlayerHolder player, L2Character target, Skill skill)
 	{
-		// TODO Auto-generated method stub
 		return false;
 	}
 	
 	@Override
 	public boolean onUseItem(PlayerHolder player, L2Item item)
 	{
+		if (item.getId() == FLAG_ITEM)
+		{
+			return true;
+		}
+		
+		if (hasFlag(player) && item instanceof L2Weapon)
+		{
+			return true;
+		}
+		
 		return false;
+	}
+	
+	@Override
+	public void onLogout(PlayerHolder player)
+	{
+		if (hasFlag(player))
+		{
+			// Remove the flag character
+			unequiFlag(player);
+			dropFlag(player);
+		}
+	}
+	
+	// VARIOUS METHODS -------------------------------------------------
+	
+	/**
+	 * Spawn flags and holders
+	 */
+	private void spawnFlagsAndHolders()
+	{
+		// red
+		int x, y, z;
+		x = ConfigData.getInstance().CTF_COORDINATES_TEAM_RED.getX();
+		y = ConfigData.getInstance().CTF_COORDINATES_TEAM_RED.getY();
+		z = ConfigData.getInstance().CTF_COORDINATES_TEAM_RED.getZ();
+		addEventNpc(RED_FLAG, x - 100, y, z, 0, Team.RED, false, getInstancesWorlds().get(0).getInstanceId());
+		addEventNpc(RED_HOLDER, x - 200, y, z, 0, Team.RED, false, getInstancesWorlds().get(0).getInstanceId());
+		// blue
+		x = ConfigData.getInstance().CTF_COORDINATES_TEAM_BLUE.getX();
+		y = ConfigData.getInstance().CTF_COORDINATES_TEAM_BLUE.getY();
+		z = ConfigData.getInstance().CTF_COORDINATES_TEAM_BLUE.getZ();
+		addEventNpc(BLUE_FLAG, x + 100, y, z, 0, Team.BLUE, false, getInstancesWorlds().get(0).getInstanceId());
+		addEventNpc(BLUE_HOLDER, x + 200, y, z, 0, Team.BLUE, false, getInstancesWorlds().get(0).getInstanceId());
+	}
+	
+	/**
+	 * We all players who are at the event and generate the teams
+	 */
+	private void createTeams()
+	{
+		// We create the instance and the world
+		InstanceWorld world = createNewInstanceWorld();
+		
+		int aux = 0;
+		
+		for (PlayerHolder player : getAllEventPlayers())
+		{
+			if ((aux % 2) == 0)
+			{
+				// Adjust the color of the title and the title character.
+				player.getPcInstance().setTeam(Team.BLUE);
+				player.setNewColorTitle(PlayerColorType.BLUE);
+				player.setNewTitle("[ BLUE ]");
+			}
+			else
+			{
+				// Adjust the color of the title and the title character.
+				player.getPcInstance().setTeam(Team.RED);
+				player.setNewColorTitle(PlayerColorType.RED);
+				player.setNewTitle("[ RED ]");
+			}
+			
+			// We add the character to the world and then be teleported
+			world.addAllowed(player.getPcInstance().getObjectId());
+			// We update the character in front of him around and himself
+			player.getPcInstance().updateAndBroadcastStatus(2);
+			// Adjust the instance that owns the character
+			player.setDinamicInstanceId(world.getInstanceId());
+			
+			aux++;
+		}
+	}
+	
+	/**
+	 * We deliver rewards.
+	 */
+	private void giveRewardsTeams()
+	{
+		if (getAllEventPlayers().isEmpty())
+		{
+			return;
+		}
+		
+		Team teamWinner = getWinTeam();
+		
+		for (PlayerHolder player : getAllEventPlayers())
+		{
+			// FIXME podriamos crear un metodo especificamente para esto pero aprovechamos el recorrido del for aqui!
+			if (hasFlag(player))
+			{
+				unequiFlag(player);
+			}
+			// We deliver rewards
+			if (player.getPcInstance().getTeam() == teamWinner)
+			{
+				giveItems(player, ConfigData.getInstance().CTF_REWARD_PLAYER_WIN);
+			}
+		}
+		
+		if (teamWinner == Team.BLUE)
+		{
+			EventUtil.announceToAllPlayersInEvent(Say2.CRITICAL_ANNOUNCE, "team_winner", "%holder%", Team.BLUE.toString());
+		}
+		else if (teamWinner == Team.RED)
+		{
+			EventUtil.announceToAllPlayersInEvent(Say2.CRITICAL_ANNOUNCE, "team_winner", "%holder%", Team.RED.toString());
+		}
+		else
+		{
+			EventUtil.announceToAllPlayersInEvent(Say2.CRITICAL_ANNOUNCE, "teams_tie");
+		}
+	}
+	
+	/**
+	 * We get the winning team<br>
+	 */
+	private Team getWinTeam()
+	{
+		Team teamWinner;
+		
+		if (_pointsRed == _pointsBlue)
+		{
+			teamWinner = Team.NONE;
+		}
+		else if (_pointsRed > _pointsBlue)
+		{
+			teamWinner = Team.RED;
+		}
+		else
+		{
+			teamWinner = Team.BLUE;
+		}
+		
+		return teamWinner;
+	}
+	
+	/**
+	 * Show on screen the number of points that each team
+	 */
+	private void showPoint()
+	{
+		for (PlayerHolder ph : getAllEventPlayers())
+		{
+			EventUtil.sendEventScreenMessage(ph, "RED " + _pointsRed + " | " + _pointsBlue + " BLUE", 10000);
+			// ph.getPcInstance().sendPacket(new EventParticipantStatus(_pointsRed, _pointsBlue));
+		}
+	}
+	
+	/**
+	 * Check if a character has a flag
+	 * @param ph
+	 * @return
+	 */
+	private boolean hasFlag(PlayerHolder ph)
+	{
+		L2ItemInstance item = ph.getPcInstance().getInventory().getPaperdollItem(Inventory.PAPERDOLL_RHAND);
+		
+		if (item != null && item.getId() == FLAG_ITEM)
+		{
+			return true;
+		}
+		
+		return false;
+	}
+	
+	/**
+	 * We equip a character with a flag
+	 * @param ph
+	 */
+	private void equipFlag(PlayerHolder ph)
+	{
+		L2ItemInstance flag = ItemTable.getInstance().createItem("", FLAG_ITEM, 1, ph.getPcInstance(), null);
+		if (flag != null)
+		{
+			ph.getPcInstance().useEquippableItem(flag, true);
+		}
+	}
+	
+	/**
+	 * We remove the flag of a character
+	 * @param ph
+	 */
+	private void unequiFlag(PlayerHolder ph)
+	{
+		L2ItemInstance flag = ph.getPcInstance().getInventory().getPaperdollItem(Inventory.PAPERDOLL_RHAND);
+		if (flag != null)
+		{
+			ph.getPcInstance().useEquippableItem(flag, true);
+		}
+	}
+	
+	private void dropFlag(PlayerHolder player)
+	{
+		Map<String, String> map = new HashMap<>();
+		switch (player.getPcInstance().getTeam())
+		{
+			case RED:
+				// New spawn for blue flag
+				addEventNpc(BLUE_FLAG, player.getPcInstance().getLocation(), Team.BLUE, getInstancesWorlds().get(0).getInstanceId());
+				// We announced that a flag was taken
+				map.put("%holder%", player.getPcInstance().getName());
+				map.put("%flag%", Team.BLUE.toString());
+				EventUtil.announceToAllPlayersInEvent(Say2.SCREEN_ANNOUNCE, "player_dropped_flag", map);
+				break;
+			case BLUE:
+				// New spawn for the red flag
+				addEventNpc(RED_FLAG, player.getPcInstance().getLocation(), Team.RED, getInstancesWorlds().get(0).getInstanceId());
+				// We announced that a flag was taken
+				map.put("%holder%", player.getPcInstance().getName());
+				map.put("%flag%", Team.RED.toString());
+				EventUtil.announceToAllPlayersInEvent(Say2.SCREEN_ANNOUNCE, "player_dropped_flag", map);
+				break;
+		}
 	}
 }

--- a/java/net/sf/eventengine/events/OneVsOne.java
+++ b/java/net/sf/eventengine/events/OneVsOne.java
@@ -18,17 +18,20 @@
  */
 package net.sf.eventengine.events;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 import net.sf.eventengine.EventEngineManager;
 import net.sf.eventengine.datatables.ConfigData;
+import net.sf.eventengine.datatables.MessageData;
+import net.sf.eventengine.enums.EventEngineState;
 import net.sf.eventengine.enums.EventState;
 import net.sf.eventengine.enums.PlayerColorType;
 import net.sf.eventengine.handler.AbstractEvent;
 import net.sf.eventengine.holder.PlayerHolder;
 import net.sf.eventengine.util.EventUtil;
 
+import com.l2jserver.gameserver.ThreadPoolManager;
 import com.l2jserver.gameserver.enums.Team;
 import com.l2jserver.gameserver.model.actor.L2Character;
 import com.l2jserver.gameserver.model.actor.L2Npc;
@@ -37,25 +40,21 @@ import com.l2jserver.gameserver.model.items.L2Item;
 import com.l2jserver.gameserver.model.skills.Skill;
 
 /**
- * One Vs One<br>
- * Al crear los equipos<br>
- * Conformaremos tantos equipos como participantes / 2.<br>
- * Cada equipo contara con 1 participante Blue y otro Red<br>
- * Cada equipo contara con su propia instancia dinamica<br>
- * <br>
  * @author fissban
  */
 public class OneVsOne extends AbstractEvent
 {
-	private static List<InstancesTeams> _instancesTeams = new ArrayList<>();
+	// time between fights in sec
+	private static final int TIME_BETWEEN_FIGHT = 10;
+	private Map<Integer, InstancesTeams> _instancesTeams = new HashMap<>();
 	
 	public OneVsOne()
 	{
 		super();
-		
-		// Definimos los spawns de cada team
-		setTeamSpawn(Team.RED, ConfigData.getInstance().OVO_COORDINATES_TEAM_1);
-		setTeamSpawn(Team.BLUE, ConfigData.getInstance().OVO_COORDINATES_TEAM_2);
+		setInstanceFile(ConfigData.getInstance().OVO_INSTANCE_FILE);
+		// We define each team spawns
+		setTeamSpawn(Team.RED, ConfigData.getInstance().OVO_COORDINATES_TEAM_RED);
+		setTeamSpawn(Team.BLUE, ConfigData.getInstance().OVO_COORDINATES_TEAM_BLUE);
 	}
 	
 	@Override
@@ -64,18 +63,18 @@ public class OneVsOne extends AbstractEvent
 		switch (state)
 		{
 			case START:
-				prepareToStart(); // Metodo general
+				prepareToStart(); // General Method
 				createTeams();
-				teleportAllPlayers();
+				teleportAllPlayers(0);
 				break;
 			
 			case FIGHT:
-				prepareToFight(); // Metodo general
+				prepareToFight(); // General Method
 				break;
 			
 			case END:
 				giveRewardsTeams();
-				prepareToEnd(); // Metodo general
+				prepareToEnd(); // General Method
 				break;
 		}
 	}
@@ -96,18 +95,17 @@ public class OneVsOne extends AbstractEvent
 	@Override
 	public void onKill(PlayerHolder player, L2Character target)
 	{
-		// XXX En este caso el control es individual y solo tendremos en cuenta los kills
-		
-		// incrementamos en uno la cantidad de kills q tiene el participantes
+		nextFight(player);
+		// One we increased the amount of kills you have the participants.
 		player.increaseKills();
+		showPoint(_instancesTeams.get(player.getDinamicInstanceId()));
 	}
 	
 	@Override
 	public void onDeath(PlayerHolder player)
 	{
-		giveResurrectPlayer(player, 10);
-		// incrementamos en uno la cantidad de muertes del personaje
-		// solo es usado al final del evento para mostrar los resultados
+		giveResurrectPlayer(player, TIME_BETWEEN_FIGHT, 0);
+		// One we increased the amount of deaths you have the participants.
 		player.increaseDeaths();
 	}
 	
@@ -123,139 +121,193 @@ public class OneVsOne extends AbstractEvent
 		return false;
 	}
 	
-	// METODOS VARIOS -------------------------------------------------
+	@Override
+	public void onLogout(PlayerHolder player)
+	{
+		//
+	}
+	
+	// VARIOUS METHODS -------------------------------------------------
 	
 	/**
-	 * Tomamos todos los players que estan registrados en el evento y generamos los teams
+	 * We all players who are registered at the event and generate the teams
 	 */
 	private void createTeams()
 	{
-		if (EventEngineManager.getInstance().isEmptyRegisteredPlayers())
-		{
-			return;
-		}
-		
-		// control para saber en q equipo estara el jugador.
+		// control variable to find out which team will be the player.
 		boolean blueOrRed = true;
-		// control para saber la cantidad de jugadores por equipo.
-		int countPlayer = 0;
+		// control variable for the amount of players per team.
+		boolean createWorld = true;
 		
 		PlayerHolder playerBlue = null;
 		PlayerHolder playerRed = null;
 		
 		InstanceWorld world = null;
 		
+		// We verified that we have an even number of participants.
+		// If not, let out a participant at random.
+		boolean leaveOutParticipant = false;
+		PlayerHolder removePlayer = null;
+		if (getAllEventPlayers().size() % 2 != 0)
+		{
+			leaveOutParticipant = true;
+		}
+		
 		for (PlayerHolder player : getAllEventPlayers())
 		{
-			if (countPlayer < 2)
+			if (leaveOutParticipant)
 			{
-				// Creamos la instancia y el mundo
-				if (countPlayer == 0)
-				{
-					world = EventEngineManager.getInstance().createNewInstanceWorld();
-				}
-				
-				// Repartimos uno para cada team
-				if (blueOrRed)
-				{
-					playerBlue = player;
-					// Ajustamos el color del titulo y el titulo del personaje.
-					player.getPcInstance().setTeam(Team.BLUE);
-					player.setNewColorTitle(PlayerColorType.BLUE);
-					player.setNewTitle("[ BLUE ]");
-					// Asignamos a la instancia q pertenecera el player.
-					player.setDinamicInstanceId(world.getInstanceId());
-				}
-				else
-				{
-					playerRed = player;
-					// Ajustamos el color del titulo y el titulo del personaje.
-					player.getPcInstance().setTeam(Team.RED);
-					player.setNewColorTitle(PlayerColorType.RED);
-					player.setNewTitle("[ RED ]");
-					// Asignamos a la instancia q pertenecera el player.
-					player.setDinamicInstanceId(world.getInstanceId());
-				}
-				
-				// alternamos entre true y false
-				blueOrRed = !blueOrRed;
-				// incrementamos en uno la cant de players
-				countPlayer++;
+				removePlayer = player;
+				leaveOutParticipant = false;
+				continue;
 			}
+			// We create the instance and the world
+			if (createWorld)
+			{
+				world = createNewInstanceWorld();
+				createWorld = false;
+			}
+			
+			// We distributed one for each team
+			if (blueOrRed)
+			{
+				playerBlue = player;
+				// Adjust the color of the title and the title character.
+				player.getPcInstance().setTeam(Team.BLUE);
+				player.setNewColorTitle(PlayerColorType.BLUE);
+				player.setNewTitle("[ BLUE ]");
+				// Assigned to the instance that owns the player.
+				player.setDinamicInstanceId(world.getInstanceId());
+			}
+			else
+			{
+				playerRed = player;
+				// Adjust the color of the title and the title character.
+				player.getPcInstance().setTeam(Team.RED);
+				player.setNewColorTitle(PlayerColorType.RED);
+				player.setNewTitle("[ RED ]");
+				// Assigned to the instance that owns the player.
+				player.setDinamicInstanceId(world.getInstanceId());
+			}
+			
+			blueOrRed = !blueOrRed;
 			
 			if ((playerRed != null) && (playerBlue != null))
 			{
-				// cargamos los diferentes teams
-				_instancesTeams.add(new InstancesTeams(playerRed, playerBlue));
-				// inicilizamos la variable
-				countPlayer = 0;
+				// We charge different teams
+				_instancesTeams.put(world.getInstanceId(), new InstancesTeams(playerRed, playerBlue));
+				// init variable
+				createWorld = true;
+				playerRed = null;
+				playerBlue = null;
 			}
-			
-			// Actualizamos al personaje frente a lo de su alrededor y a si mismo
-			player.getPcInstance().updateAndBroadcastStatus(2);
+		}
+		
+		// stir a character of the event.
+		if (removePlayer != null)
+		{
+			// TODO podriamos enviarle un mensaje notificando lo sucedido.
+			getAllEventPlayers().remove(removePlayer);
 		}
 	}
 	
 	/**
-	 * Entregamos los rewards, por el momento solo tenemos soporte para 1 o 2 teams.
+	 * We deliver rewards for the moment we only support for 1 or 2 teams.
 	 */
 	private void giveRewardsTeams()
 	{
-		if (EventEngineManager.getInstance().isEmptyRegisteredPlayers())
+		if (getAllEventPlayers().isEmpty())
 		{
 			return;
 		}
 		
-		for (InstancesTeams team : _instancesTeams)
+		for (InstancesTeams team : _instancesTeams.values())
 		{
-			// TODO falta verificar si los players estan conectados.
-			
-			// Averiguamos q jugador tiene la mayor cant de kills de este equipo
-			int pointsBlue = team._playerBlue.getKills();
-			int pointsRed = team._playerRed.getKills();
-			
-			if (pointsBlue == pointsRed)// Si ambos tienen la misma cantidad de kills reciviran ambos el premio de perdedor.
+			// If both players are offline any prize will be awarded.
+			if (team._playerRed.getPcInstance() == null && team._playerBlue.getPcInstance() == null)
 			{
-				// Anunciamos el resultado del evento
-				EventUtil.sendEventScreenMessage(team._playerBlue, "El evento resulto en un empate entre ambos teams!");
-				EventUtil.sendEventScreenMessage(team._playerRed, "El evento resulto en un empate entre ambos teams!");
-				
-				// Entregamos los rewards
-				if (ConfigData.getInstance().OVO_REWARD_TEAM_TIE)
-				{
-					giveItems(team._playerBlue, ConfigData.getInstance().OVO_REWARD_PLAYER_WIN);
-					giveItems(team._playerRed, ConfigData.getInstance().OVO_REWARD_PLAYER_WIN);
-				}
+				continue;
 			}
-			else if (pointsBlue < pointsRed)// ganador red
+			
+			/** Verify that the blue player follow in the event. */
+			if (team._playerBlue.getPcInstance() == null)
 			{
-				// Anunciamos el resultado del evento
-				EventUtil.sendEventScreenMessage(team._playerBlue, "El evento fue ganado por el jugador RED!");
-				EventUtil.sendEventScreenMessage(team._playerRed, "El evento fue ganado por el jugador RED!");
-				
-				// Entregamos los rewards
+				EventUtil.sendEventScreenMessage(team._playerRed, MessageData.getInstance().getMsgByLang(team._playerBlue.getPcInstance(), "winner_red", false));
 				giveItems(team._playerRed, ConfigData.getInstance().OVO_REWARD_PLAYER_WIN);
 			}
-			else if (pointsBlue > pointsRed)// ganador blue
+			/** Verify that the red player follow in the event.. */
+			else if (team._playerRed.getPcInstance() == null)
 			{
-				// Anunciamos el resultado del evento
-				EventUtil.sendEventScreenMessage(team._playerBlue, "El evento fue ganado por el jugador BLUE!");
-				EventUtil.sendEventScreenMessage(team._playerRed, "El evento fue ganado por el jugador BLUE!");
-				
-				// Entregamos los rewards
+				EventUtil.sendEventScreenMessage(team._playerBlue, MessageData.getInstance().getMsgByLang(team._playerBlue.getPcInstance(), "winner_blue", false));
 				giveItems(team._playerBlue, ConfigData.getInstance().OVO_REWARD_PLAYER_WIN);
+			}
+			/** If both players continue to verify the event points. */
+			else
+			{
+				int pointsBlue = team._playerBlue.getKills();
+				int pointsRed = team._playerRed.getKills();
+				
+				if (pointsBlue == pointsRed)// tie
+				{
+					
+					EventUtil.sendEventScreenMessage(team._playerBlue, MessageData.getInstance().getMsgByLang(team._playerBlue.getPcInstance(), "event_tie", false));
+					EventUtil.sendEventScreenMessage(team._playerRed, MessageData.getInstance().getMsgByLang(team._playerRed.getPcInstance(), "event_tie", false));
+				}
+				else if (pointsBlue < pointsRed)// win red
+				{
+					EventUtil.sendEventScreenMessage(team._playerRed, MessageData.getInstance().getMsgByLang(team._playerRed.getPcInstance(), "winner_red", false));
+					giveItems(team._playerRed, ConfigData.getInstance().OVO_REWARD_PLAYER_WIN);
+				}
+				else if (pointsBlue > pointsRed)// win blue
+				{
+					EventUtil.sendEventScreenMessage(team._playerBlue, MessageData.getInstance().getMsgByLang(team._playerBlue.getPcInstance(), "winner_blue", false));
+					giveItems(team._playerBlue, ConfigData.getInstance().OVO_REWARD_PLAYER_WIN);
+				}
 			}
 		}
 	}
 	
+	private void nextFight(PlayerHolder ph)
+	{
+		ThreadPoolManager.getInstance().scheduleGeneral(new Runnable()
+		{
+			@Override
+			public void run()
+			{
+				if (EventEngineManager.getInstance().getEventEngineState() == EventEngineState.RUNNING_EVENT)
+				{
+					// heal to max
+					ph.getPcInstance().setCurrentCp(ph.getPcInstance().getMaxCp());
+					ph.getPcInstance().setCurrentHp(ph.getPcInstance().getMaxHp());
+					ph.getPcInstance().setCurrentMp(ph.getPcInstance().getMaxMp());
+					// teleport
+					teleportPlayer(ph, 0);
+					// buff
+					giveBuffPlayer(ph.getPcInstance());
+				}
+			}
+			
+		}, TIME_BETWEEN_FIGHT * 1000);
+	}
+	
 	/**
-	 * Clase encargada de administrar los puntos de los teams de cada instancia
+	 * Show on screen the number of points that each team
+	 */
+	private void showPoint(InstancesTeams instTeams)
+	{
+		EventUtil.sendEventScreenMessage(instTeams._playerBlue, "RED " + instTeams._playerRed.getPoints() + " | " + instTeams._playerBlue.getPoints() + " BLUE", 10000);
+		EventUtil.sendEventScreenMessage(instTeams._playerRed, "RED " + instTeams._playerRed.getPoints() + " | " + instTeams._playerBlue.getPoints() + " BLUE", 10000);
+		// ph.getPcInstance().sendPacket(new EventParticipantStatus(_pointsRed, _pointsBlue));
+	}
+	
+	/**
+	 * Class responsible for managing the points of the teams in each instance
 	 * @author fissban
 	 */
 	private class InstancesTeams
 	{
-		public PlayerHolder _playerRed;
-		public PlayerHolder _playerBlue;
+		private PlayerHolder _playerRed;
+		private PlayerHolder _playerBlue;
 		
 		public InstancesTeams(PlayerHolder playerRed, PlayerHolder playerBlue)
 		{

--- a/java/net/sf/eventengine/events/Survive.java
+++ b/java/net/sf/eventengine/events/Survive.java
@@ -20,7 +20,6 @@ package net.sf.eventengine.events;
 
 import java.util.List;
 
-import net.sf.eventengine.EventEngineManager;
 import net.sf.eventengine.datatables.ConfigData;
 import net.sf.eventengine.enums.EventState;
 import net.sf.eventengine.enums.PlayerColorType;
@@ -39,24 +38,25 @@ import com.l2jserver.gameserver.network.clientpackets.Say2;
 import com.l2jserver.util.Rnd;
 
 /**
- * Evento de supervivencia<br>
- * Se creara un unico team y tendran que sobrevivir durante varias oleadas de mobs,<br>
+ * Event survival<br>
+ * One team will be created and will have to survive several waves of mobs.<br>
  * @author fissban
  */
 public class Survive extends AbstractEvent
 {
-	// Variable que controlara el nivel del stage.
+	// Variable that controls the level of the stage
 	private int _stage = 1;
-	// Variable que nos ayudara a llevar el control de la cantidad de mobs muertos.
+	// Variable that helps us keep track of the number of dead mobs.
 	private int _auxKillMonsters = 0;
 	
-	// Id de los monsters
-	private static final List<Integer> MONSTERS_ID = ConfigData.getInstance().SURVIVE_MONSTERS_ID;
+	// Monsters ids
+	private final List<Integer> MONSTERS_ID = ConfigData.getInstance().SURVIVE_MONSTERS_ID;
 	
 	public Survive()
 	{
 		super();
-		// Definimos los spawns de cada team
+		setInstanceFile(ConfigData.getInstance().SURVIVE_INSTANCE_FILE);
+		// We define the main spawn of equipment
 		setTeamSpawn(Team.BLUE, ConfigData.getInstance().SURVIVE_COORDINATES_PLAYER);
 	}
 	
@@ -66,19 +66,19 @@ public class Survive extends AbstractEvent
 		switch (state)
 		{
 			case START:
-				prepareToStart(); // Metodo general
+				prepareToStart(); // General Method
 				createTeam();
-				teleportAllPlayers();
+				teleportAllPlayers(200);
 				break;
 			
 			case FIGHT:
-				prepareToFight(); // Metodo general
+				prepareToFight(); // General Method
 				spawnsMobs();
 				break;
 			
 			case END:
 				// showResult();
-				prepareToEnd(); // Metodo general
+				prepareToEnd(); // General Method
 				break;
 		}
 	}
@@ -86,30 +86,28 @@ public class Survive extends AbstractEvent
 	@Override
 	public void onInteract(PlayerHolder player, L2Npc npc)
 	{
-		// TODO Auto-generated method stub
+		//
 	}
 	
 	@Override
 	public void onKill(PlayerHolder player, L2Character target)
 	{
-		// La instancia al ser "NO PVP" no hace falta tener en cuenta q maten a un compañero.
-		
-		// Nos servira para llevar el recuento de cuantos mobs mato.
+		// We serve to keep count of how many mobs killed.
 		player.increaseKills();
-		// Actualizamos el titulo de un personaje
+		// Update title character
 		updateTitle(player);
-		// Incrementamos en uno la cantidad de mobs muertos
+		// One increasing the amount of dead mobs
 		_auxKillMonsters++;
-		// Verificamos la cantidad de mobs muertos, de haberlos matados a todos aumentamos en uno el stage.
+		// Verify the number of dead mobs, if any killed all increase by one the stage.
 		if (_auxKillMonsters >= (_stage * ConfigData.getInstance().SURVIVE_MONSTER_SPAWN_FOR_STAGE))
 		{
-			// aumentamos en uno el stage.
+			// Increase by one the stage.
 			_stage++;
-			// reiniciamos nuestro auxiliar.
+			// We restart our assistant.
 			_auxKillMonsters = 0;
-			// spawneamos mas mobs
+			// Spawns Mobs
 			spawnsMobs();
-			// Entregamos los rewards por haber pasado de stage
+			// Give rewards
 			giveRewardsTeams();
 		}
 	}
@@ -142,6 +140,12 @@ public class Survive extends AbstractEvent
 		return false;
 	}
 	
+	@Override
+	public void onLogout(PlayerHolder player)
+	{
+		//
+	}
+	
 	// MISC ---------------------------------------------------------------------------------------
 	public void giveRewardsTeams()
 	{
@@ -150,12 +154,9 @@ public class Survive extends AbstractEvent
 			return;
 		}
 		
-		// Entregamos los rewards y anunciamos los ganadores.
 		for (PlayerHolder player : getAllEventPlayers())
 		{
-			// Enviamos un mensaje al ganador
 			EventUtil.sendEventScreenMessage(player, "Felicitaciones sobreviviente");
-			// Entregamos los rewards
 			giveItems(player, ConfigData.getInstance().SURVIVE_REWARD_PLAYER_WIN);
 		}
 	}
@@ -164,64 +165,59 @@ public class Survive extends AbstractEvent
 	{
 		EventUtil.announceToAllPlayersInEvent(Say2.BATTLEFIELD, "Ya llegan, preparate!");
 		
-		// Transcurridos 5 segs se ejecutara el spawn.
+		// After 5 secs spawn run.
 		ThreadPoolManager.getInstance().scheduleGeneral(new Runnable()
 		{
 			@Override
 			public void run()
 			{
-				// Spawneamos los mobs dependiendo del nivel del stage dentro de la unica instancia creada.
 				for (int i = 0; i < (_stage * ConfigData.getInstance().SURVIVE_MONSTER_SPAWN_FOR_STAGE); i++)
 				{
-					L2Npc eventNpc = addEventNpc(MONSTERS_ID.get(Rnd.get(MONSTERS_ID.size() - 1)), 149539, 46712, -3411, 0, true, EventEngineManager.getInstance().getInstancesWorlds().get(0).getInstanceId());
-					// Definimos un team para el monster.
-					// Solo usado como un efecto.
-					eventNpc.setTeam(Team.RED);
+					addEventNpc(MONSTERS_ID.get(Rnd.get(MONSTERS_ID.size() - 1)), ConfigData.getInstance().SURVIVE_COORDINATES_PLAYER, Team.RED, true, getInstancesWorlds().get(0).getInstanceId());
 				}
 				
-				// Avisamos a los personajes del evento en q stage estan actualmente.
+				// We notify the characters in the event that stage they are currently.
 				for (PlayerHolder ph : getAllEventPlayers())
 				{
 					EventUtil.sendEventScreenMessage(ph, "Stage " + _stage, 5000);
 				}
 			}
-			
 		}, 5000L);
 		
 	}
 	
 	/**
-	 * Creamos el equipo donde jugaran los personajes
+	 * We create the computer that will play the characters.
 	 */
 	private void createTeam()
 	{
-		// Creamos la instancia y el mundo
-		InstanceWorld world = EventEngineManager.getInstance().createNewInstanceWorld();
+		// We create the instance and the world
+		InstanceWorld world = createNewInstanceWorld();
 		
 		for (PlayerHolder ph : getAllEventPlayers())
 		{
-			// Agregamos el personaje al mundo para luego ser teletransportado
+			// We add the character to the world and then be teleported
 			world.addAllowed(ph.getPcInstance().getObjectId());
-			// Ajustamos el team de los personaje
+			// Adjust the team of character
 			ph.getPcInstance().setTeam(Team.BLUE);
-			// Ajustamos la instancia a al que perteneceran los personaje
+			// Adjust the instance that owns the character
 			ph.setDinamicInstanceId(world.getInstanceId());
-			// Ajustamos el color del titulo
+			// Adjust the color of the title
 			ph.setNewColorTitle(PlayerColorType.YELLOW_OCHRE);
-			// Ajustamos el titulo del personaje.
+			// Adjust the title character.
 			updateTitle(ph);
 		}
 	}
 	
 	/**
-	 * Actualizamos el titulo de un personaje dependiendo de la cantidad de kills q tenga
+	 * We update the title of a character depending on the number of murders that have
 	 * @param player
 	 */
 	private void updateTitle(PlayerHolder player)
 	{
-		// Ajustamos el titulo del pesonaje
+		// Adjust the title character.
 		player.setNewTitle("Monster Death " + player.getKills());
-		// Actualizamos el status del personaje
+		// Adjust the status character.
 		player.getPcInstance().updateAndBroadcastStatus(2);
 	}
 }

--- a/java/net/sf/eventengine/events/TeamVsTeam.java
+++ b/java/net/sf/eventengine/events/TeamVsTeam.java
@@ -21,7 +21,6 @@ package net.sf.eventengine.events;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.sf.eventengine.EventEngineManager;
 import net.sf.eventengine.datatables.ConfigData;
 import net.sf.eventengine.enums.EventState;
 import net.sf.eventengine.enums.PlayerColorType;
@@ -42,17 +41,17 @@ import com.l2jserver.gameserver.model.skills.Skill;
  */
 public class TeamVsTeam extends AbstractEvent
 {
-	// Puntos que tiene cada team.
+	// Points that each team.
 	private int _pointsRed = 0;
 	private int _pointsBlue = 0;
 	
 	public TeamVsTeam()
 	{
 		super();
-		
-		// Definimos los spawns de cada team
-		setTeamSpawn(Team.RED, ConfigData.getInstance().TVT_COORDINATES_TEAM_1);
-		setTeamSpawn(Team.BLUE, ConfigData.getInstance().TVT_COORDINATES_TEAM_2);
+		setInstanceFile(ConfigData.getInstance().TVT_INSTANCE_FILE);
+		// We define each team spawns
+		setTeamSpawn(Team.RED, ConfigData.getInstance().TVT_COORDINATES_TEAM_RED);
+		setTeamSpawn(Team.BLUE, ConfigData.getInstance().TVT_COORDINATES_TEAM_BLUE);
 	}
 	
 	@Override
@@ -61,20 +60,20 @@ public class TeamVsTeam extends AbstractEvent
 		switch (state)
 		{
 			case START:
-				prepareToStart(); // Metodo general
+				prepareToStart(); // General Method
 				createTeams();
-				teleportAllPlayers();
+				teleportAllPlayers(300);
 				break;
 			
 			case FIGHT:
-				prepareToFight(); // Metodo general
+				prepareToFight(); // General Method
 				showPoint();
 				break;
 			
 			case END:
 				// showResult();
 				giveRewardsTeams();
-				prepareToEnd(); // Metodo general
+				prepareToEnd(); // General Method
 				break;
 		}
 	}
@@ -95,7 +94,7 @@ public class TeamVsTeam extends AbstractEvent
 	@Override
 	public void onKill(PlayerHolder player, L2Character target)
 	{
-		// Incrementamos los puntos del team.
+		// We increased the team's points.
 		switch (player.getPcInstance().getTeam())
 		{
 			case RED:
@@ -112,9 +111,8 @@ public class TeamVsTeam extends AbstractEvent
 	@Override
 	public void onDeath(PlayerHolder player)
 	{
-		giveResurrectPlayer(player, 10);
-		// incrementamos en uno la cantidad de muertes del personaje
-		// solo es usado al final del evento para mostrar los resultados
+		giveResurrectPlayer(player, 10, 300);
+		// Incremented by one the number of deaths Character
 		player.increaseDeaths();
 	}
 	
@@ -130,15 +128,21 @@ public class TeamVsTeam extends AbstractEvent
 		return false;
 	}
 	
-	// METODOS VARIOS -------------------------------------------------
+	@Override
+	public void onLogout(PlayerHolder player)
+	{
+		//
+	}
+	
+	// VARIOUS METHODS -------------------------------------------------
 	
 	/**
-	 * Tomamos todos los players que estan registrados en el evento y generamos los teams
+	 * We all players who are at the event and generate the teams
 	 */
 	private void createTeams()
 	{
-		// Creamos la instancia y el mundo
-		InstanceWorld world = EventEngineManager.getInstance().createNewInstanceWorld();
+		// We create the instance and the world
+		InstanceWorld world = createNewInstanceWorld();
 		
 		int aux = 0;
 		
@@ -146,24 +150,24 @@ public class TeamVsTeam extends AbstractEvent
 		{
 			if ((aux % 2) == 0)
 			{
-				// Ajustamos el color del titulo y el titulo del personaje.
+				// Adjust the color of the title and the title character.
 				player.getPcInstance().setTeam(Team.BLUE);
 				player.setNewColorTitle(PlayerColorType.BLUE);
 				player.setNewTitle("[ BLUE ]");
 			}
 			else
 			{
-				// Ajustamos el color del titulo y el titulo del personaje.
+				// Adjust the color of the title and the title character.
 				player.getPcInstance().setTeam(Team.RED);
 				player.setNewColorTitle(PlayerColorType.RED);
 				player.setNewTitle("[ RED ]");
 			}
 			
-			// Agregamos el personaje al mundo para luego ser teletransportado
+			// We add the character to the world and then be teleported
 			world.addAllowed(player.getPcInstance().getObjectId());
-			// Actualizamos al personaje frente a lo de su alrededor y a si mismo
+			// Character status update
 			player.getPcInstance().updateAndBroadcastStatus(2);
-			// Ajustamos la instancia a al que perteneceran los personaje
+			// Adjust the instance which will own the character
 			player.setDinamicInstanceId(world.getInstanceId());
 			
 			aux++;
@@ -171,37 +175,31 @@ public class TeamVsTeam extends AbstractEvent
 	}
 	
 	/**
-	 * Entregamos los rewards, por el momento solo tenemos soporte para 1 o 2 teams.
+	 * Entregamos los rewards
 	 */
 	private void giveRewardsTeams()
 	{
-		if (EventEngineManager.getInstance().isEmptyRegisteredPlayers())
+		if (getAllEventPlayers().isEmpty())
 		{
 			return;
 		}
 		
-		Team ganador = getWinTeam();
+		Team teamWinner = getWinTeam();
 		
 		for (PlayerHolder player : getAllEventPlayers())
 		{
-			if (ganador == Team.NONE)
+			if (teamWinner == Team.NONE)
 			{
-				// Anunciamos el resultado del evento
+				// Send Message
 				EventUtil.sendEventScreenMessage(player, "El evento resulto en un empate entre ambos teams!");
-				
-				// Entregamos los rewards
-				if (ConfigData.getInstance().OVO_REWARD_TEAM_TIE)
-				{
-					giveItems(player, ConfigData.getInstance().TVT_REWARD_PLAYER_WIN);
-				}
 			}
 			else
 			{
-				// Anunciamos el resultado del evento
-				EventUtil.sendEventScreenMessage(player, "Equipo ganador -> " + ganador.getClass().getCanonicalName() + "!");
+				// Send Message
+				EventUtil.sendEventScreenMessage(player, "Equipo ganador -> " + teamWinner.toString() + "!");
 				
 				// Entregamos los rewards
-				if (player.getPcInstance().getTeam() == ganador)
+				if (player.getPcInstance().getTeam() == teamWinner)
 				{
 					giveItems(player, ConfigData.getInstance().TVT_REWARD_PLAYER_WIN);
 				}
@@ -211,37 +209,33 @@ public class TeamVsTeam extends AbstractEvent
 	}
 	
 	/**
-	 * Pequeño codigo para obtener al team ganador<br>
-	 * Solo es usado para ahorrar codigo.
+	 * Small code for the winning team<br>
 	 */
 	private Team getWinTeam()
 	{
-		// Si ambos equipos tienen la misma cant de puntos creo q lo justo es q ambos son perdedores :P
-		Team ganador;
+		Team teamWinner;
 		
 		if (_pointsRed == _pointsBlue)
 		{
-			ganador = Team.NONE;
+			teamWinner = Team.NONE;
 		}
 		else if (_pointsRed > _pointsBlue)
 		{
-			ganador = Team.RED;
+			teamWinner = Team.RED;
 		}
 		else
 		{
-			ganador = Team.BLUE;
+			teamWinner = Team.BLUE;
 		}
 		
-		return ganador;
+		return teamWinner;
 	}
 	
 	/**
-	 * Mostramos por pantalla la canidad de puntos q tiene cada team
+	 * Show on screen the number of points that each team
 	 */
 	private void showPoint()
 	{
-		// Enviamos por pantalla los puntajes a todos en el evento
-		
 		for (PlayerHolder ph : getAllEventPlayers())
 		{
 			EventUtil.sendEventScreenMessage(ph, "RED " + _pointsRed + " | " + _pointsBlue + " BLUE", 10000);
@@ -250,7 +244,7 @@ public class TeamVsTeam extends AbstractEvent
 	}
 	
 	/**
-	 * Creamos listados con todos los participantes y le enviamos a cada uno los resultados finales del evento
+	 * Create lists with all participants and send to each final results of the event
 	 */
 	private void showResult()
 	{
@@ -270,7 +264,6 @@ public class TeamVsTeam extends AbstractEvent
 			}
 		}
 		
-		// Enviamos a todos los resultados finales del evento
 		for (PlayerHolder ph : getAllEventPlayers())
 		{
 			ph.getPcInstance().sendPacket(new EventParticipantStatus(_pointsRed, teamBlue, _pointsBlue, teamRed));

--- a/java/net/sf/eventengine/handler/AbstractEvent.java
+++ b/java/net/sf/eventengine/handler/AbstractEvent.java
@@ -18,6 +18,7 @@
  */
 package net.sf.eventengine.handler;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -25,6 +26,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 
 import net.sf.eventengine.EventEngineManager;
+import net.sf.eventengine.EventEngineWorld;
 import net.sf.eventengine.datatables.BuffListData;
 import net.sf.eventengine.datatables.ConfigData;
 import net.sf.eventengine.datatables.MessageData;
@@ -37,6 +39,7 @@ import com.l2jserver.gameserver.ThreadPoolManager;
 import com.l2jserver.gameserver.data.xml.impl.NpcData;
 import com.l2jserver.gameserver.datatables.SpawnTable;
 import com.l2jserver.gameserver.enums.Team;
+import com.l2jserver.gameserver.instancemanager.InstanceManager;
 import com.l2jserver.gameserver.model.L2Spawn;
 import com.l2jserver.gameserver.model.Location;
 import com.l2jserver.gameserver.model.actor.L2Character;
@@ -44,6 +47,7 @@ import com.l2jserver.gameserver.model.actor.L2Npc;
 import com.l2jserver.gameserver.model.actor.L2Playable;
 import com.l2jserver.gameserver.model.actor.L2Summon;
 import com.l2jserver.gameserver.model.actor.instance.L2CubicInstance;
+import com.l2jserver.gameserver.model.actor.instance.L2DoorInstance;
 import com.l2jserver.gameserver.model.actor.instance.L2PcInstance;
 import com.l2jserver.gameserver.model.actor.templates.L2NpcTemplate;
 import com.l2jserver.gameserver.model.holders.ItemHolder;
@@ -73,6 +77,58 @@ public abstract class AbstractEvent
 	/** Necessary to keep track of the states of the event. */
 	public abstract void runEventState(EventState state);
 	
+	// XXX DINAMIC INSTANCE ------------------------------------------------------------------------------
+	private String _instanceFile = "";
+	
+	public void setInstanceFile(String instanceFile)
+	{
+		_instanceFile = instanceFile;
+	}
+	
+	private final List<InstanceWorld> _instanceWorlds = new ArrayList<>();
+	
+	/**
+	 * Create dynamic instances and a world for her
+	 * @param count
+	 * @return InstanceWorld
+	 */
+	public InstanceWorld createNewInstanceWorld()
+	{
+		InstanceWorld world = null;
+		try
+		{
+			int instanceId = InstanceManager.getInstance().createDynamicInstance(_instanceFile);
+			InstanceManager.getInstance().getInstance(instanceId).setAllowSummon(false);
+			InstanceManager.getInstance().getInstance(instanceId).setPvPInstance(true);
+			InstanceManager.getInstance().getInstance(instanceId).setEmptyDestroyTime(1000 + 60000L);
+			// We closed the doors of the instance if there
+			for (L2DoorInstance door : InstanceManager.getInstance().getInstance(instanceId).getDoors())
+			{
+				door.closeMe();
+			}
+			
+			world = new EventEngineWorld();
+			world.setInstanceId(instanceId);
+			world.setTemplateId(100); // TODO hardcode
+			world.setStatus(0);
+			InstanceManager.getInstance().addWorld(world);
+			_instanceWorlds.add(world);
+			
+		}
+		catch (Exception e)
+		{
+			LOGGER.warning(EventEngineManager.class.getSimpleName() + ": -> createDynamicInstances() " + e);
+			e.printStackTrace();
+		}
+		
+		return world;
+	}
+	
+	public List<InstanceWorld> getInstancesWorlds()
+	{
+		return _instanceWorlds;
+	}
+	
 	// NPC IN EVENT --------------------------------------------------------------------------------- //
 	
 	// List of NPC in the event.
@@ -89,14 +145,31 @@ public abstract class AbstractEvent
 	
 	/**
 	 * We generate a new spawn in our event and added to the list.
+	 */
+	public L2Npc addEventNpc(int npcId, Location loc, Team team, int instanceId)
+	{
+		return addEventNpc(npcId, loc.getX(), loc.getY(), loc.getZ(), loc.getHeading(), team, false, instanceId);
+	}
+	
+	/**
+	 * We generate a new spawn in our event and added to the list.
+	 */
+	public L2Npc addEventNpc(int npcId, Location loc, Team team, boolean randomOffset, int instanceId)
+	{
+		return addEventNpc(npcId, loc.getX(), loc.getY(), loc.getZ(), loc.getHeading(), team, randomOffset, instanceId);
+	}
+	
+	/**
+	 * We generate a new spawn in our event and added to the list.
 	 * @param npcId
 	 * @param x
 	 * @param y
 	 * @param z
 	 * @param heading
-	 * @param randomOffset -> 100
+	 * @param randomOffset -> +/- 1000
+	 * @return L2Npc
 	 */
-	public L2Npc addEventNpc(int npcId, int x, int y, int z, int heading, boolean randomOffset, int instanceId)
+	public L2Npc addEventNpc(int npcId, int x, int y, int z, int heading, Team team, boolean randomOffset, int instanceId)
 	{
 		// We generate our npc spawn
 		L2Npc npc = null;
@@ -119,6 +192,7 @@ public abstract class AbstractEvent
 				spawn.setAmount(1);
 				spawn.setInstanceId(instanceId);
 				npc = spawn.doSpawn();// isSummonSpawn.
+				npc.setTeam(team);
 				
 				SpawnTable.getInstance().addNewSpawn(spawn, false);
 				spawn.init();
@@ -132,7 +206,7 @@ public abstract class AbstractEvent
 			return null;
 		}
 		// We add our npc to the list.
-		_eventNpc.put(npc.getId(), npc);
+		_eventNpc.put(npc.getObjectId(), npc);
 		
 		return npc;
 	}
@@ -165,7 +239,17 @@ public abstract class AbstractEvent
 	 */
 	public boolean isNpcInEvent(L2Npc npc)
 	{
-		return _eventNpc.containsValue(npc);
+		return _eventNpc.containsValue(npc.getObjectId());
+	}
+	
+	public void removeNpc(L2Npc npc)
+	{
+		// We stopped the npc spawn.
+		npc.getSpawn().stopRespawn();
+		// Delete the npc.
+		npc.deleteMe();
+		
+		_eventNpc.remove(npc.getObjectId());
 	}
 	
 	// SPAWNS TEAMS ---------------------------------------------------------------------------------- //
@@ -204,12 +288,34 @@ public abstract class AbstractEvent
 	}
 	
 	/**
-	 * We add all the characters registered to our list of characters in the event.
+	 * We add all the characters registered to our list of characters in the event.<br>
+	 * Check if player in olympiad.<br>
+	 * Check if player in duel<br>
+	 * Check if player in observer mode<br>
 	 */
 	private void createEventPlayers()
 	{
 		for (L2PcInstance player : EventEngineManager.getInstance().getAllRegisteredPlayers())
 		{
+			// Check if player in olympiad.
+			if (player.isInOlympiadMode())
+			{
+				player.sendMessage("You can not attend the event being in the Olympics.");
+				continue;
+			}
+			// Check if player in duel
+			if (player.isInDuel())
+			{
+				player.sendMessage("You can not attend the event being in the Duel.");
+				continue;
+			}
+			// Check if player in observer mode
+			if (player.inObserverMode())
+			{
+				player.sendMessage("You can not attend the event being in the Observer mode.");
+				continue;
+			}
+			
 			_eventPlayers.put(player.getObjectId(), new PlayerHolder(player));
 		}
 		
@@ -219,7 +325,7 @@ public abstract class AbstractEvent
 	
 	/**
 	 * Check if the playable is participating in any event. In the case of a summon, verify that the owner participates <br>
-	 * For not participate in an event is returned <u> false </ u>
+	 * For not participate in an event is returned <u> false </u>
 	 * @param player
 	 * @return boolean
 	 */
@@ -241,7 +347,7 @@ public abstract class AbstractEvent
 	/**
 	 * Check if a player is participating in any event. <br>
 	 * In the case of dealing with a summon you verify the owner. <br>
-	 * For an event not perticipar returns <u> null </ u>
+	 * For an event not perticipar returns <u> null </u>
 	 * @param character
 	 * @return PlayerHolder
 	 */
@@ -289,6 +395,13 @@ public abstract class AbstractEvent
 	public void listenerOnKill(L2Playable playable, L2Character target)
 	{
 		if (!isPlayableInEvent(playable))
+		{
+			return;
+		}
+		
+		// ignoramos siempre si matan algun summon.
+		// XXX se podria usar en algun evento...analizar!
+		if (target.isSummon())
 		{
 			return;
 		}
@@ -361,8 +474,8 @@ public abstract class AbstractEvent
 	public abstract boolean onAttack(PlayerHolder player, L2Character target);
 	
 	/**
-	 * @param playable -> personaje o summon
-	 * @param target -> puede ser null
+	 * @param playable
+	 * @param target
 	 * @return true -> only in the event that an skill not want that continue its normal progress.
 	 */
 	public boolean listenerOnUseSkill(L2Playable playable, L2Character target, Skill skill)
@@ -449,16 +562,44 @@ public abstract class AbstractEvent
 	 */
 	public abstract boolean onUseItem(PlayerHolder player, L2Item item);
 	
+	public void listenerOnLogout(L2PcInstance player)
+	{
+		if (isPlayableInEvent(player))
+		{
+			try
+			{
+				PlayerHolder ph = getEventPlayer(player);
+				// listener
+				onLogout(ph);
+				// recover the original color title
+				ph.recoverOriginalColorTitle();
+				// recover the original title
+				ph.recoverOriginalTitle();
+				// we remove the character of the created world
+				InstanceManager.getInstance().getWorld(ph.getDinamicInstanceId()).removeAllowed(ph.getPcInstance().getObjectId());
+				
+				getAllEventPlayers().remove(ph);
+			}
+			catch (Exception e)
+			{
+				LOGGER.warning(EventEngineManager.class.getSimpleName() + ": -> listenerOnLogout() " + e);
+				e.printStackTrace();
+			}
+		}
+	}
+	
+	public abstract void onLogout(PlayerHolder player);
+	
 	// VARIOUS METHODS. -------------------------------------------------------------------------------- //
 	
 	/**
 	 * Teleport to players of each team to their respective starting points<br>
 	 */
-	public void teleportAllPlayers()
+	public void teleportAllPlayers(int radius)
 	{
 		for (PlayerHolder player : getAllEventPlayers())
 		{
-			teleportPlayer(player);
+			teleportPlayer(player, radius);
 		}
 	}
 	
@@ -466,12 +607,22 @@ public abstract class AbstractEvent
 	 * Teleport to a specific player to its original location within the event.
 	 * @param player
 	 */
-	public void teleportPlayer(PlayerHolder player)
+	public void teleportPlayer(PlayerHolder player, int radius)
 	{
 		// get the spawn defined at the start of each event
 		Location loc = getTeamSpawn(player.getPcInstance().getTeam());
+		// verify if character is dead
+		if (player.getPcInstance().isDead())
+		{
+			DecayTaskManager.getInstance().cancel(player.getPcInstance());
+			player.getPcInstance().doRevive();
+			// heal to max
+			player.getPcInstance().setCurrentCp(player.getPcInstance().getMaxCp());
+			player.getPcInstance().setCurrentHp(player.getPcInstance().getMaxHp());
+			player.getPcInstance().setCurrentMp(player.getPcInstance().getMaxMp());
+		}
 		// teleport to character
-		player.getPcInstance().teleToLocation(loc.getX(), loc.getY(), loc.getZ(), loc.getHeading(), player.getDinamicInstanceId());
+		player.getPcInstance().teleToLocation(loc.getX() + Rnd.get(-radius, radius), loc.getY() + Rnd.get(-radius, radius), loc.getZ(), loc.getHeading(), player.getDinamicInstanceId());
 		
 	}
 	
@@ -564,13 +715,11 @@ public abstract class AbstractEvent
 			// We canceled the Team
 			player.getPcInstance().setTeam(Team.NONE);
 			// It out of the world created for the event
-			for (InstanceWorld world : EventEngineManager.getInstance().getInstancesWorlds())
-			{
-				if (player.getDinamicInstanceId() == world.getInstanceId())
-				{
-					world.removeAllowed(player.getPcInstance().getObjectId());
-				}
-			}
+			
+			InstanceWorld world = InstanceManager.getInstance().getPlayerWorld(player.getPcInstance());
+			world.removeAllowed(player.getPcInstance().getObjectId());
+			player.getPcInstance().setInstanceId(0);
+			
 			// FIXME We send a character to their actual instance and turn
 			player.getPcInstance().teleToLocation(83437, 148634, -3403, 0, 0);// GIRAN CENTER
 		}
@@ -589,8 +738,9 @@ public abstract class AbstractEvent
 	 * <li>We canceled the invul and let you move</li><br>
 	 * @param player
 	 * @param time
+	 * @param radiusTeleport
 	 */
-	public void giveResurrectPlayer(final PlayerHolder player, int time)
+	public void giveResurrectPlayer(final PlayerHolder player, int time, int radiusTeleport)
 	{
 		try
 		{
@@ -608,9 +758,9 @@ public abstract class AbstractEvent
 					player.getPcInstance().setCurrentHp(player.getPcInstance().getMaxHp());
 					player.getPcInstance().setCurrentMp(player.getPcInstance().getMaxMp());
 					// teleport
-					EventEngineManager.getInstance().getCurrentEvent().teleportPlayer(player);
+					teleportPlayer(player, radiusTeleport);
 					// buff
-					EventEngineManager.getInstance().getCurrentEvent().giveBuffPlayer(player.getPcInstance());
+					giveBuffPlayer(player.getPcInstance());
 				}
 				
 			}, time * 1000);

--- a/java/net/sf/eventengine/util/EventUtil.java
+++ b/java/net/sf/eventengine/util/EventUtil.java
@@ -19,6 +19,7 @@
 package net.sf.eventengine.util;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -166,6 +167,31 @@ public class EventUtil
 	 */
 	public static void announceToAllPlayersInEvent(int say2, String text)
 	{
+		announceToAllPlayersInEvent(say2, text, null);
+	}
+	
+	/**
+	 * Send a message to all players in the event
+	 * @param say2
+	 * @param text
+	 * @param replace
+	 * @param textReplace
+	 */
+	public static void announceToAllPlayersInEvent(int say2, String text, String replace, String textReplace)
+	{
+		Map<String, String> map = new HashMap<>();
+		map.put(replace, textReplace);
+		announceToAllPlayersInEvent(say2, text, map);
+	}
+	
+	/**
+	 * Send a message to all players in the event
+	 * @param say2
+	 * @param text
+	 * @param map : used to replace the holders with the proper text
+	 */
+	public static void announceToAllPlayersInEvent(int say2, String text, Map<String, String> mapToReplace)
+	{
 		AbstractEvent event = EventEngineManager.getInstance().getCurrentEvent();
 		
 		if (event == null)
@@ -175,7 +201,17 @@ public class EventUtil
 		
 		for (PlayerHolder ph : event.getAllEventPlayers())
 		{
-			ph.getPcInstance().sendPacket(new CreatureSay(0, say2, "", MessageData.getInstance().getMsgByLang(ph.getPcInstance(), text, true)));
+			String announce = MessageData.getInstance().getMsgByLang(ph.getPcInstance(), text, true);
+			
+			if (mapToReplace != null)
+			{
+				for (String key : mapToReplace.keySet())
+				{
+					announce = announce.replace(key, mapToReplace.get(key));
+				}
+			}
+			
+			ph.getPcInstance().sendPacket(new CreatureSay(0, say2, "", announce));
 		}
 	}
 	
@@ -186,10 +222,7 @@ public class EventUtil
 	 */
 	public static void announceToAllPlayers(int say2, String text)
 	{
-		for (L2PcInstance player : L2World.getInstance().getPlayers())
-		{
-			player.sendPacket(new CreatureSay(0, say2, "", MessageData.getInstance().getMsgByLang(player, text, true)));
-		}
+		announceToAllPlayers(say2, text, null);
 	}
 	
 	/**
@@ -201,9 +234,31 @@ public class EventUtil
 	 */
 	public static void announceToAllPlayers(int say2, String text, String replace, String textReplace)
 	{
+		Map<String, String> map = new HashMap<>();
+		map.put(replace, textReplace);
+		announceToAllPlayers(say2, text, map);
+	}
+	
+	/**
+	 * Send a message to all online players
+	 * @param say2
+	 * @param text
+	 */
+	public static void announceToAllPlayers(int say2, String text, Map<String, String> mapToReplace)
+	{
 		for (L2PcInstance player : L2World.getInstance().getPlayers())
 		{
-			player.sendPacket(new CreatureSay(0, say2, "", MessageData.getInstance().getMsgByLang(player, text, true).replace(replace, textReplace)));
+			String announce = MessageData.getInstance().getMsgByLang(player, text, true);
+			
+			if (mapToReplace != null)
+			{
+				for (String key : mapToReplace.keySet())
+				{
+					announce = announce.replace(key, mapToReplace.get(key));
+				}
+			}
+			
+			player.sendPacket(new CreatureSay(0, say2, "", announce));
 		}
 	}
 }

--- a/java/net/sf/eventengine/util/SortUtil.java
+++ b/java/net/sf/eventengine/util/SortUtil.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2015-2015 L2J EventEngine
+ *
+ * This file is part of L2J EventEngine.
+ *
+ * L2J EventEngine is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * L2J EventEngine is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.sf.eventengine.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.sf.eventengine.holder.PlayerHolder;
+
+/**
+ * @author Zephyr
+ */
+public class SortUtil
+{
+	public static ArrayList<List<PlayerHolder>> getOrderedByKills(List<PlayerHolder> list, int level)
+	{
+		int max = -1;
+		int previousMax = 10000;
+		int index = -1;
+		ArrayList<List<PlayerHolder>> result = new ArrayList<>();
+		
+		while (level > 0)
+		{
+			// Get the max value
+			for (PlayerHolder player : list)
+			{
+				if (player.getKills() < previousMax && player.getKills() > max)
+				{
+					max = player.getKills();
+				}
+			}
+			
+			result.add(new ArrayList<>());
+			index++;
+			
+			// Put the players with the max value
+			for (PlayerHolder player : list)
+			{
+				if (player.getKills() == max)
+				{
+					result.get(index).add(player);
+				}
+			}
+			previousMax = max;
+			max = -1;
+			level--;
+		}
+		
+		return result;
+	}
+}


### PR DESCRIPTION
## Summary
- The world instances now are handled by event instance
- Capture the Flag reworked
- One vs One reworked (disabled for now)
- Documentation (comments) of all events translated
- Fix: The npcs during events weren't removed when their event finished
- Now, we can define the mob/npc team when the event spawns them.
- Before starting the event, it validates the player's state (olympiad, duel,
  spectator mode).
- ListenerOnKill works with playables and npcs
- More functions for listenerOnLogout
- Improvements to teleport players outside instance when the event finishs
- 'Radius' parameter added to teleport method
- Now the player is revived before teleporting him
