### PR TITLE
Add event global/range npc message setting

### DIFF
--- a/dist/game/config/EventEngine/EventEngine.properties
+++ b/dist/game/config/EventEngine/EventEngine.properties
@@ -9,12 +9,18 @@
 # Default: 36600
 EventParticipationNpcId = 36600
 
+# Event global message
+# Options 1: True = Global
+# Options 2: False = Range
+# Default: True
+EventGlobalMessage = True
+
 # Interval time between events (minutes)
 # Default: 10
 EventInterval = 10
 
 # Enable voting time
-# Default: true
+# Default: True
 EventVotingEnabled = True
 
 # Event voting time (minutes)

--- a/dist/game/config/EventEngine/Language/lang_en.xml
+++ b/dist/game/config/EventEngine/Language/lang_en.xml
@@ -111,5 +111,8 @@
 	
 	<!-- All vs All -->
 	<message id="ava_first_place" text="First place: %holder%"/>
+	
+	<!-- Survive -->
+	<message id="survive_spawns_mobs" text="Here come, get ready!"/>
 
 </localization>

--- a/java/net/sf/eventengine/datatables/BuffListData.java
+++ b/java/net/sf/eventengine/datatables/BuffListData.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -56,7 +55,7 @@ public class BuffListData implements IXmlReader
 	public void load()
 	{
 		parseDatapackFile("config/EventEngine/xml/buff_list.xml");
-		LOGGER.log(Level.INFO, getClass().getSimpleName() + ": Loaded: " + _buffList.size() + " Buffs.");
+		LOGGER.info("{}: Loaded {} Buffs.", getClass().getSimpleName(), _buffList.size());
 	}
 	
 	@Override

--- a/java/net/sf/eventengine/datatables/ConfigData.java
+++ b/java/net/sf/eventengine/datatables/ConfigData.java
@@ -41,6 +41,7 @@ public class ConfigData
 	
 	// General configs
 	public int NPC_MANAGER_ID;
+	public boolean EVENT_MESSAGE_GLOBAL;
 	public int EVENT_TASK;
 	public boolean EVENT_VOTING_ENABLED;
 	public int EVENT_VOTING_TIME;
@@ -114,6 +115,7 @@ public class ConfigData
 		// ------------------------------------------------------------------------------------- //
 		settings = new EventPropertiesParser(EVENT_CONFIG);
 		NPC_MANAGER_ID = settings.getInt("EventParticipationNpcId", 36600);
+		EVENT_MESSAGE_GLOBAL = settings.getBoolean("EventGlobalMessage", true);
 		EVENT_TASK = settings.getInt("EventInterval", 10);
 		EVENT_VOTING_ENABLED = settings.getBoolean("EventVotingEnabled", true);
 		EVENT_VOTING_TIME = settings.getInt("EventVotingTime", 10);

--- a/java/net/sf/eventengine/enums/CollectionTarget.java
+++ b/java/net/sf/eventengine/enums/CollectionTarget.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2015-2015 L2J EventEngine
+ *
+ * This file is part of L2J EventEngine.
+ *
+ * L2J EventEngine is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * L2J EventEngine is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.sf.eventengine.enums;
+
+/**
+ * @author Zephyr
+ */
+public enum CollectionTarget
+{
+	ALL_PLAYERS,
+	ALL_PLAYERS_REGISTERED,
+	ALL_PLAYERS_IN_EVENT,
+	ALL_NEAR_PLAYERS,
+	ALL_NEAR_PLAYERS_REGISTERED
+}

--- a/java/net/sf/eventengine/events/AllVsAll.java
+++ b/java/net/sf/eventengine/events/AllVsAll.java
@@ -21,14 +21,6 @@ package net.sf.eventengine.events;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.sf.eventengine.datatables.ConfigData;
-import net.sf.eventengine.enums.EventState;
-import net.sf.eventengine.enums.PlayerColorType;
-import net.sf.eventengine.handler.AbstractEvent;
-import net.sf.eventengine.holder.PlayerHolder;
-import net.sf.eventengine.util.EventUtil;
-import net.sf.eventengine.util.SortUtil;
-
 import com.l2jserver.gameserver.enums.Team;
 import com.l2jserver.gameserver.model.actor.L2Character;
 import com.l2jserver.gameserver.model.actor.L2Npc;
@@ -37,6 +29,15 @@ import com.l2jserver.gameserver.model.items.L2Item;
 import com.l2jserver.gameserver.model.skills.Skill;
 import com.l2jserver.gameserver.network.clientpackets.Say2;
 import com.l2jserver.util.Rnd;
+
+import net.sf.eventengine.datatables.ConfigData;
+import net.sf.eventengine.enums.CollectionTarget;
+import net.sf.eventengine.enums.EventState;
+import net.sf.eventengine.enums.PlayerColorType;
+import net.sf.eventengine.handler.AbstractEvent;
+import net.sf.eventengine.holder.PlayerHolder;
+import net.sf.eventengine.util.EventUtil;
+import net.sf.eventengine.util.SortUtil;
 
 /**
  * @author fissban
@@ -61,11 +62,11 @@ public class AllVsAll extends AbstractEvent
 				createTeam();
 				teleportAllPlayers(1000);
 				break;
-			
+				
 			case FIGHT:
 				prepareToFight(); // General Method
 				break;
-			
+				
 			case END:
 				giveRewardsTeams();
 				prepareToEnd(); // General Method
@@ -185,6 +186,6 @@ public class AllVsAll extends AbstractEvent
 			giveItems(player, ConfigData.getInstance().AVA_REWARD_PLAYER_WIN);
 		}
 		
-		EventUtil.announceToAllPlayers(Say2.CRITICAL_ANNOUNCE, "ava_first_place", "%holder%", winners);
+		EventUtil.announceTo(Say2.CRITICAL_ANNOUNCE, "ava_first_place", "%holder%", winners, CollectionTarget.ALL_PLAYERS_IN_EVENT);
 	}
 }

--- a/java/net/sf/eventengine/events/CaptureTheFlag.java
+++ b/java/net/sf/eventengine/events/CaptureTheFlag.java
@@ -21,13 +21,6 @@ package net.sf.eventengine.events;
 import java.util.HashMap;
 import java.util.Map;
 
-import net.sf.eventengine.datatables.ConfigData;
-import net.sf.eventengine.enums.EventState;
-import net.sf.eventengine.enums.PlayerColorType;
-import net.sf.eventengine.handler.AbstractEvent;
-import net.sf.eventengine.holder.PlayerHolder;
-import net.sf.eventengine.util.EventUtil;
-
 import com.l2jserver.gameserver.datatables.ItemTable;
 import com.l2jserver.gameserver.enums.Team;
 import com.l2jserver.gameserver.model.actor.L2Character;
@@ -39,6 +32,14 @@ import com.l2jserver.gameserver.model.items.L2Weapon;
 import com.l2jserver.gameserver.model.items.instance.L2ItemInstance;
 import com.l2jserver.gameserver.model.skills.Skill;
 import com.l2jserver.gameserver.network.clientpackets.Say2;
+
+import net.sf.eventengine.datatables.ConfigData;
+import net.sf.eventengine.enums.CollectionTarget;
+import net.sf.eventengine.enums.EventState;
+import net.sf.eventengine.enums.PlayerColorType;
+import net.sf.eventengine.handler.AbstractEvent;
+import net.sf.eventengine.holder.PlayerHolder;
+import net.sf.eventengine.util.EventUtil;
 
 /**
  * @author fissban
@@ -80,11 +81,11 @@ public class CaptureTheFlag extends AbstractEvent
 				spawnFlagsAndHolders();
 				teleportAllPlayers(100);
 				break;
-			
+				
 			case FIGHT:
 				prepareToFight(); // General Method
 				break;
-			
+				
 			case END:
 				giveRewardsTeams();
 				prepareToEnd(); // General Method
@@ -105,10 +106,10 @@ public class CaptureTheFlag extends AbstractEvent
 					// We remove the flag from his position
 					removeNpc(npc);
 					// We announced that a flag was taken
-					EventUtil.announceToAllPlayersInEvent(Say2.SCREEN_ANNOUNCE, "ctf_captured_the_flag", "%holder%", Team.RED.toString());
+					EventUtil.announceTo(Say2.SCREEN_ANNOUNCE, "ctf_captured_the_flag", "%holder%", Team.RED.toString(), CollectionTarget.ALL_PLAYERS_IN_EVENT);
 				}
 				break;
-			
+				
 			case RED_FLAG:
 				if (player.getPcInstance().getTeam() == Team.BLUE)
 				{
@@ -117,10 +118,10 @@ public class CaptureTheFlag extends AbstractEvent
 					// We remove the flag from his position
 					removeNpc(npc);
 					// We announced that a flag was taken
-					EventUtil.announceToAllPlayersInEvent(Say2.SCREEN_ANNOUNCE, "ctf_captured_the_flag", "%holder%", Team.BLUE.toString());
+					EventUtil.announceTo(Say2.SCREEN_ANNOUNCE, "ctf_captured_the_flag", "%holder%", Team.BLUE.toString(), CollectionTarget.ALL_PLAYERS_IN_EVENT);
 				}
 				break;
-			
+				
 			case BLUE_HOLDER:
 				if (player.getPcInstance().getTeam() == Team.BLUE)
 				{
@@ -133,13 +134,13 @@ public class CaptureTheFlag extends AbstractEvent
 						// We created the flag again
 						addEventNpc(RED_FLAG, ConfigData.getInstance().CTF_COORDINATES_TEAM_RED, Team.RED, getInstancesWorlds().get(0).getInstanceId());
 						// We announced that a flag was taken
-						EventUtil.announceToAllPlayersInEvent(Say2.SCREEN_ANNOUNCE, "ctf_conquered_the_flag", "%holder%", Team.BLUE.toString());
+						EventUtil.announceTo(Say2.SCREEN_ANNOUNCE, "ctf_conquered_the_flag", "%holder%", Team.BLUE.toString(), CollectionTarget.ALL_PLAYERS_IN_EVENT);
 						// Show points of each team
 						showPoint();
 					}
 				}
 				break;
-			
+				
 			case RED_HOLDER:
 				if (player.getPcInstance().getTeam() == Team.RED)
 				{
@@ -152,7 +153,7 @@ public class CaptureTheFlag extends AbstractEvent
 						// We created the flag again
 						addEventNpc(BLUE_FLAG, ConfigData.getInstance().CTF_COORDINATES_TEAM_BLUE, Team.BLUE, getInstancesWorlds().get(0).getInstanceId());
 						// We announced that a flag was taken
-						EventUtil.announceToAllPlayersInEvent(Say2.SCREEN_ANNOUNCE, "ctf_conquered_the_flag", "%holder%", Team.RED.toString());
+						EventUtil.announceTo(Say2.SCREEN_ANNOUNCE, "ctf_conquered_the_flag", "%holder%", Team.RED.toString(), CollectionTarget.ALL_PLAYERS_IN_EVENT);
 						// Show points of each team
 						showPoint();
 					}
@@ -321,15 +322,15 @@ public class CaptureTheFlag extends AbstractEvent
 		
 		if (teamWinner == Team.BLUE)
 		{
-			EventUtil.announceToAllPlayersInEvent(Say2.CRITICAL_ANNOUNCE, "team_winner", "%holder%", Team.BLUE.toString());
+			EventUtil.announceTo(Say2.CRITICAL_ANNOUNCE, "team_winner", "%holder%", Team.BLUE.toString(), CollectionTarget.ALL_PLAYERS_IN_EVENT);
 		}
 		else if (teamWinner == Team.RED)
 		{
-			EventUtil.announceToAllPlayersInEvent(Say2.CRITICAL_ANNOUNCE, "team_winner", "%holder%", Team.RED.toString());
+			EventUtil.announceTo(Say2.CRITICAL_ANNOUNCE, "team_winner", "%holder%", Team.RED.toString(), CollectionTarget.ALL_PLAYERS_IN_EVENT);
 		}
 		else
 		{
-			EventUtil.announceToAllPlayersInEvent(Say2.CRITICAL_ANNOUNCE, "teams_tie");
+			EventUtil.announceTo(Say2.CRITICAL_ANNOUNCE, "teams_tie", CollectionTarget.ALL_PLAYERS_IN_EVENT);
 		}
 	}
 	
@@ -422,7 +423,7 @@ public class CaptureTheFlag extends AbstractEvent
 				// We announced that a flag was taken
 				map.put("%holder%", player.getPcInstance().getName());
 				map.put("%flag%", Team.BLUE.toString());
-				EventUtil.announceToAllPlayersInEvent(Say2.SCREEN_ANNOUNCE, "player_dropped_flag", map);
+				EventUtil.announceTo(Say2.SCREEN_ANNOUNCE, "player_dropped_flag", map, CollectionTarget.ALL_PLAYERS_IN_EVENT);
 				break;
 			case BLUE:
 				// New spawn for the red flag
@@ -430,7 +431,7 @@ public class CaptureTheFlag extends AbstractEvent
 				// We announced that a flag was taken
 				map.put("%holder%", player.getPcInstance().getName());
 				map.put("%flag%", Team.RED.toString());
-				EventUtil.announceToAllPlayersInEvent(Say2.SCREEN_ANNOUNCE, "player_dropped_flag", map);
+				EventUtil.announceTo(Say2.SCREEN_ANNOUNCE, "player_dropped_flag", map, CollectionTarget.ALL_PLAYERS_IN_EVENT);
 				break;
 		}
 	}

--- a/java/net/sf/eventengine/events/Survive.java
+++ b/java/net/sf/eventengine/events/Survive.java
@@ -21,6 +21,7 @@ package net.sf.eventengine.events;
 import java.util.List;
 
 import net.sf.eventengine.datatables.ConfigData;
+import net.sf.eventengine.enums.CollectionTarget;
 import net.sf.eventengine.enums.EventState;
 import net.sf.eventengine.enums.PlayerColorType;
 import net.sf.eventengine.handler.AbstractEvent;
@@ -156,14 +157,14 @@ public class Survive extends AbstractEvent
 		
 		for (PlayerHolder player : getAllEventPlayers())
 		{
-			EventUtil.sendEventScreenMessage(player, "Felicitaciones sobreviviente");
+			EventUtil.sendEventScreenMessage(player, "Congratulations survivor!");
 			giveItems(player, ConfigData.getInstance().SURVIVE_REWARD_PLAYER_WIN);
 		}
 	}
 	
 	private void spawnsMobs()
 	{
-		EventUtil.announceToAllPlayersInEvent(Say2.BATTLEFIELD, "Ya llegan, preparate!");
+		EventUtil.announceTo(Say2.BATTLEFIELD, "survive_spawns_mobs", CollectionTarget.ALL_PLAYERS_IN_EVENT);
 		
 		// After 5 secs spawn run.
 		ThreadPoolManager.getInstance().scheduleGeneral(new Runnable()

--- a/java/net/sf/eventengine/events/TeamVsTeam.java
+++ b/java/net/sf/eventengine/events/TeamVsTeam.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.sf.eventengine.datatables.ConfigData;
+import net.sf.eventengine.enums.CollectionTarget;
 import net.sf.eventengine.enums.EventState;
 import net.sf.eventengine.enums.PlayerColorType;
 import net.sf.eventengine.handler.AbstractEvent;
@@ -35,6 +36,7 @@ import com.l2jserver.gameserver.model.actor.L2Npc;
 import com.l2jserver.gameserver.model.instancezone.InstanceWorld;
 import com.l2jserver.gameserver.model.items.L2Item;
 import com.l2jserver.gameserver.model.skills.Skill;
+import com.l2jserver.gameserver.network.clientpackets.Say2;
 
 /**
  * @author fissban
@@ -188,24 +190,25 @@ public class TeamVsTeam extends AbstractEvent
 		
 		for (PlayerHolder player : getAllEventPlayers())
 		{
-			if (teamWinner == Team.NONE)
+			// We deliver rewards
+			if (player.getPcInstance().getTeam() == teamWinner)
 			{
-				// Send Message
-				EventUtil.sendEventScreenMessage(player, "El evento resulto en un empate entre ambos teams!");
-			}
-			else
-			{
-				// Send Message
-				EventUtil.sendEventScreenMessage(player, "Equipo ganador -> " + teamWinner.toString() + "!");
-				
-				// Entregamos los rewards
-				if (player.getPcInstance().getTeam() == teamWinner)
-				{
-					giveItems(player, ConfigData.getInstance().TVT_REWARD_PLAYER_WIN);
-				}
+				giveItems(player, ConfigData.getInstance().TVT_REWARD_PLAYER_WIN);
 			}
 		}
 		
+		if (teamWinner == Team.BLUE)
+		{
+			EventUtil.announceTo(Say2.CRITICAL_ANNOUNCE, "team_winner", "%holder%", Team.BLUE.toString(), CollectionTarget.ALL_PLAYERS_IN_EVENT);
+		}
+		else if (teamWinner == Team.RED)
+		{
+			EventUtil.announceTo(Say2.CRITICAL_ANNOUNCE, "team_winner", "%holder%", Team.RED.toString(), CollectionTarget.ALL_PLAYERS_IN_EVENT);
+		}
+		else
+		{
+			EventUtil.announceTo(Say2.CRITICAL_ANNOUNCE, "teams_tie", CollectionTarget.ALL_PLAYERS_IN_EVENT);
+		}
 	}
 	
 	/**

--- a/java/net/sf/eventengine/task/EventTask.java
+++ b/java/net/sf/eventengine/task/EventTask.java
@@ -18,13 +18,14 @@
  */
 package net.sf.eventengine.task;
 
+import com.l2jserver.gameserver.network.clientpackets.Say2;
+
 import net.sf.eventengine.EventEngineManager;
+import net.sf.eventengine.enums.CollectionTarget;
 import net.sf.eventengine.enums.EventEngineState;
 import net.sf.eventengine.enums.EventState;
 import net.sf.eventengine.holder.PlayerHolder;
 import net.sf.eventengine.util.EventUtil;
-
-import com.l2jserver.gameserver.network.clientpackets.Say2;
 
 /**
  * Clase encargada de correr los diferentes estados q sufren los diferentes eventos
@@ -46,14 +47,14 @@ public class EventTask implements Runnable
 		{
 			case 1:
 				// Anunciamos a los players q pronto seran teletransportados
-				EventUtil.announceToAllPlayersInEvent(Say2.CRITICAL_ANNOUNCE, "teleport_seconds");
+				EventUtil.announceTo(Say2.CRITICAL_ANNOUNCE, "teleport_seconds", CollectionTarget.ALL_PLAYERS_IN_EVENT);
 				break;
-			
+				
 			case 2:
 				/** Se ejecutan acciones dentro de cada evento */
 				EventEngineManager.getInstance().getCurrentEvent().runEventState(EventState.START);
 				break;
-			
+				
 			case 3:
 				/** Se ejecutan acciones dentro de cada evento */
 				EventEngineManager.getInstance().getCurrentEvent().runEventState(EventState.FIGHT);
@@ -64,7 +65,7 @@ public class EventTask implements Runnable
 					EventUtil.sendEventSpecialMessage(player, 2, "status_started");
 				}
 				break;
-			
+				
 			case 4:
 				/** Se ejecutan acciones dentro de cada evento */
 				EventEngineManager.getInstance().getCurrentEvent().runEventState(EventState.END);
@@ -78,7 +79,7 @@ public class EventTask implements Runnable
 					EventUtil.sendEventSpecialMessage(player, 1, "status_finished");
 				}
 				break;
-			
+				
 			case 5:
 				// Volvemos a habilitar el registro
 				EventEngineManager.getInstance().setEventEngineState(EventEngineState.EVENT_ENDED);


### PR DESCRIPTION
## Summary

Announce messages reworked, now allows a different types of announces:
- Near
- Registered players
- All players
- Players in event

Also, you can use several holders in announces.
