### PR TITLE
Event Engine - Up Pack

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -4,5 +4,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/L2J_Server"/>
 	<classpathentry kind="lib" path="/L2J_Server/dist/libs/mmocore.jar"/>
+	<classpathentry kind="lib" path="/L2J_Server/dist/libs/slf4j-api-1.7.12.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/Diff_DataPack.txt
+++ b/Diff_DataPack.txt
@@ -36,25 +36,9 @@ index 94fe9c4..5b80dc8 100644
  					}
  					else
  					{
-+						// L2J EventEngine
++						// L2J-EventEngine
 +						EventEngineManager.getInstance().listenerOnInteract(activeChar, npc);
 +						
  						if (npc.hasListener(EventType.ON_NPC_QUEST_START))
  						{
  							activeChar.setLastQuestNpcObject(npc.getObjectId());
-diff --git a/L2J_DataPack/dist/game/data/stats/npcs/custom/custom.xml b/L2J_DataPack/dist/game/data/stats/npcs/custom/custom.xml
-index 18f8f27..bda47fa 100644
---- a/L2J_DataPack/dist/game/data/stats/npcs/custom/custom.xml
-+++ b/L2J_DataPack/dist/game/data/stats/npcs/custom/custom.xml
-@@ -58,4 +58,10 @@
- 			<height normal="22.25" />
- 		</collision>
- 	</npc>
-+		<npc id="36600" displayId="32226" name="EventEngine" usingServerSideName="true" title="L2J" usingServerSideTitle="true" type="L2Npc">
-+		<collision>
-+			<radius normal="11" />
-+			<height normal="22.25" />
-+		</collision>
-+	</npc>
- </list>
-\ No newline at end of file

--- a/Diff_Server.txt
+++ b/Diff_Server.txt
@@ -1,5 +1,5 @@
 diff --git a/L2J_Server/.classpath b/L2J_Server/.classpath
-index 05e3150..0057726 100644
+index 05e3150..0b47f01 100644
 --- a/L2J_Server/.classpath
 +++ b/L2J_Server/.classpath
 @@ -1,13 +1,14 @@
@@ -18,7 +18,7 @@ index 05e3150..0057726 100644
 -</classpath>
 \ No newline at end of file
 +	<classpathentry kind="src" path="java"/>
-+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
++	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/jdk1.8.0_51"/>
 +	<classpathentry kind="lib" path="dist/libs/c3p0-0.9.5.jar"/>
 +	<classpathentry kind="lib" path="dist/libs/jython.jar"/>
 +	<classpathentry kind="lib" path="dist/libs/jython-engine-2.2.1.jar"/>
@@ -31,7 +31,7 @@ index 05e3150..0057726 100644
 +</classpath>
 diff --git a/L2J_Server/dist/libs/L2J_EventEngine.jar b/L2J_Server/dist/libs/L2J_EventEngine.jar
 new file mode 100644
-index 0000000..b8ab609
+index 0000000..223838b
 --- /dev/null
 +++ b/L2J_Server/dist/libs/L2J_EventEngine.jar
 Binary files differ
@@ -87,7 +87,7 @@ index 9bb51e3..ddbc2e1 100644
  		if ((returnBack != null) && returnBack.terminate())
  		{
 diff --git a/L2J_Server/java/com/l2jserver/gameserver/model/actor/L2Playable.java b/L2J_Server/java/com/l2jserver/gameserver/model/actor/L2Playable.java
-index cbe50df..74069b8 100644
+index cbe50df..12fc0f3 100644
 --- a/L2J_Server/java/com/l2jserver/gameserver/model/actor/L2Playable.java
 +++ b/L2J_Server/java/com/l2jserver/gameserver/model/actor/L2Playable.java
 @@ -18,6 +18,8 @@
@@ -99,7 +99,7 @@ index cbe50df..74069b8 100644
  import com.l2jserver.gameserver.ai.CtrlEvent;
  import com.l2jserver.gameserver.enums.InstanceType;
  import com.l2jserver.gameserver.instancemanager.InstanceManager;
-@@ -106,6 +108,28 @@
+@@ -106,8 +108,36 @@
  	}
  	
  	@Override
@@ -127,7 +127,15 @@ index cbe50df..74069b8 100644
 +	@Override
  	public boolean doDie(L2Character killer)
  	{
++		// L2J EventEngine
++		if ((killer != null) && killer.isPlayable())
++		{
++			EventEngineManager.getInstance().listenerOnKill((L2Playable) killer, this);
++		}
++		
  		final TerminateReturn returnBack = EventDispatcher.getInstance().notifyEvent(new OnCreatureKill(killer, this), this, TerminateReturn.class);
+ 		if ((returnBack != null) && returnBack.terminate())
+ 		{
 diff --git a/L2J_Server/java/com/l2jserver/gameserver/model/actor/instance/L2PcInstance.java b/L2J_Server/java/com/l2jserver/gameserver/model/actor/instance/L2PcInstance.java
 index ebe0026..30bc90d 100644
 --- a/L2J_Server/java/com/l2jserver/gameserver/model/actor/instance/L2PcInstance.java

--- a/Diff_Server.txt
+++ b/Diff_Server.txt
@@ -53,8 +53,8 @@ index 25de90c..29c8050 100644
  			_deadDetectThread = null;
  		}
 +		
-+		// L2J EventEngine
-+		printSection("L2J EventEngine");
++		// L2J-EventEngine
++		printSection("L2J-EventEngine");
 +		EventEngineManager.getInstance();
 +		
  		System.gc();
@@ -77,7 +77,7 @@ index 9bb51e3..ddbc2e1 100644
  	 */
  	public boolean doDie(L2Character killer)
  	{
-+		// L2J EventEngine
++		// L2J-EventEngine
 +		if ((killer != null) && killer.isPlayable())
 +		{
 +			EventEngineManager.getInstance().listenerOnKill((L2Playable) killer, this);
@@ -105,7 +105,7 @@ index cbe50df..12fc0f3 100644
  	@Override
 +	public void doAttack(L2Character target)
 +	{
-+		// L2J EventEngine
++		// L2J-EventEngine
 +		if (EventEngineManager.getInstance().listenerOnAttack(this, target))
 +		{
 +			return;
@@ -116,7 +116,7 @@ index cbe50df..12fc0f3 100644
 +	@Override
 +	public void doCast(Skill skill)
 +	{
-+		// L2J EventEngine
++		// L2J-EventEngine
 +		if (EventEngineManager.getInstance().listenerOnUseSkill(this, (L2Character) getTarget(), skill))
 +		{
 +			return;
@@ -127,7 +127,7 @@ index cbe50df..12fc0f3 100644
 +	@Override
  	public boolean doDie(L2Character killer)
  	{
-+		// L2J EventEngine
++		// L2J-EventEngine
 +		if ((killer != null) && killer.isPlayable())
 +		{
 +			EventEngineManager.getInstance().listenerOnKill((L2Playable) killer, this);
@@ -162,7 +162,7 @@ index ebe0026..30bc90d 100644
  				}
  			}
  		}
-+		// L2J EventEngine
++		// L2J-EventEngine
 +		EventEngineManager.getInstance().listenerOnDeath(this);
  		
  		// Kill the L2PcInstance
@@ -182,7 +182,7 @@ index ebe0026..30bc90d 100644
  			return false;
 +		}
 +		
-+		// L2J EventEngine
++		// L2J-EventEngine
 +		if (EventEngineManager.getInstance().isPlayerInEvent(this))
 +		{
 +			return true;
@@ -193,7 +193,7 @@ index ebe0026..30bc90d 100644
  			_log.log(Level.SEVERE, "deleteMe()", e);
  		}
  		
-+		// L2J EventEngine
++		// L2J-EventEngine
 +		EventEngineManager.getInstance().listenerOnLogout(this);
 +		
  		// TvT Event removal
@@ -216,7 +216,7 @@ index 3f038d0..a353c38 100644
  			return SystemMessage.getSystemMessage(SystemMessageId.THE_GAME_HAS_BEEN_CANCELLED_BECAUSE_THE_OTHER_PARTY_ENDS_THE_GAME);
  		}
  		
-+		// L2J EventEngine
++		// L2J-EventEngine
 +		if (EventEngineManager.getInstance().isPlayableInEvent(player))
 +		{
 +			return SystemMessage.getSystemMessage(SystemMessageId.THE_GAME_HAS_BEEN_CANCELLED_BECAUSE_THE_OTHER_PARTY_DOES_NOT_MEET_THE_REQUIREMENTS_FOR_JOINING_THE_GAME);
@@ -242,7 +242,7 @@ index 3d3da22..f1b3a77 100644
  		activeChar.sendMessage(getText("Q29weXJpZ2h0IDIwMDQtMjAxNA=="));
  		activeChar.sendMessage(getText("VGhhbmsgeW91IGZvciAxMCB5ZWFycyE="));
  		
-+		// L2J EventEngine
++		// L2J-EventEngine
 +		EventEngineManager.getInstance().listenerOnLogin(activeChar);
 +		
  		SevenSigns.getInstance().sendCurrentPeriodMsg(activeChar);
@@ -265,7 +265,7 @@ index 640e695..8267663 100644
  			}
  		}
  		
-+		// L2J EventEngine
++		// L2J-EventEngine
 +		if (EventEngineManager.getInstance().listenerOnUseItem(activeChar, item.getItem()))
 +		{
 +			return;
@@ -301,7 +301,7 @@ index 108ae76..bb14a3a 100644
  		writeC(0x00);
  		writeD(_charObjId);
 +		
-+		// L2J EventEngine
++		// L2J-EventEngine
 +		if (_activeChar.isPlayer() && EventEngineManager.getInstance().isPlayerInEvent((L2PcInstance) _activeChar))
 +		{
 +			_canTeleport = false;

--- a/dist/game/config/EventEngine/AllVsAll.properties
+++ b/dist/game/config/EventEngine/AllVsAll.properties
@@ -7,17 +7,21 @@
 
 # Enable/Disable AvA Event
 # Default: True
-AvAEventEnabled = True
+EventEnabled = True
+
+# Name of the instance file for events
+# Default: EventEngine.xml
+EventInstanceFile = EventEngine.xml
 
 # Reward for winning player
-# Example: AvAEventReward = itemId,amount;itemId,amount;itemId,amount
-AvAEventReward =  57,10000;
+# Example: EventReward  = itemId,amount;itemId,amount;itemId,amount
+EventReward = 57,10000;
 
 # Reward for kill player
 # Example: AvAEventRewardKill = itemId,amount;itemId,amount;itemId,amount
-AvAEventRewardKill = 57,100;
+EventRewardKill = 57,100;
 
 # Player spawn, Start/Death x,y,z location
 # Format: x,y,z
 # Example: 148695,46725,-3414
-AvAEventCoordinates = 149474,46745,-3408
+EventCoordinates = 149474,46745,-3408

--- a/dist/game/config/EventEngine/CaptureTheFlag.properties
+++ b/dist/game/config/EventEngine/CaptureTheFlag.properties
@@ -1,0 +1,36 @@
+# ================================================================
+# CONFIGURATION FOR EVENT CAPTURE THE FLAG
+# ================================================================
+# Commands assigned to the configuration of the events
+# More information: L2J_EventEngine Web/Forum
+# ================================================================
+
+# Enable/Disable CTF Event
+# Default: True
+EventEnabled = True
+
+# Name of the instance file for events
+# Default: EventEngine.xml
+EventInstanceFile = EventEngine.xml
+
+# Reward for winning player
+# Example: EventReward  = itemId,amount;itemId,amount;itemId,amount
+EventReward = 57,10000;
+
+# First Team - Name, Start/Death x,y,z location
+# Format: x,y,z
+# Example: 148695,46725,-3414
+EventTeam1Coordinates = 148695,46725,-3414
+
+# Second Team - Name, Start/Death x,y,z location
+# Format: x,y,z
+# Example: 149999,46728,-3414
+EventTeam2Coordinates = 149999,46728,-3414
+
+# Points to conquer the flag
+# Default: 10
+EventPointsConquerFlag = 10
+
+# Points to kill players
+# Default: 1
+EventPointsKill = 1

--- a/dist/game/config/EventEngine/EventEngine.properties
+++ b/dist/game/config/EventEngine/EventEngine.properties
@@ -9,10 +9,6 @@
 # Default: 36600
 EventParticipationNpcId = 36600
 
-# Name of the instance file for events
-# Default: EventEngine.xml
-EventInstanceFile = EventEngine.xml
-
 # Interval time between events (minutes)
 # Default: 10
 EventInterval = 10
@@ -32,6 +28,10 @@ EventRegisterTime = 10
 # Event running time (in minutes).
 # Default: 10
 EventRunningTime = 10
+
+# Spawn/Respawn delay timer (in seconds).
+# Default: 10
+EventTeleportPlayerDelay = 10
 
 # Enabled Friend Fire
 # Default: False

--- a/dist/game/config/EventEngine/OneVsOne.properties
+++ b/dist/game/config/EventEngine/OneVsOne.properties
@@ -7,22 +7,30 @@
 
 # Enable/Disable OvO Event
 # Default: False
-OvOEventEnabled = False
+EventEnabled = False
+
+# Name of the instance file for events
+# Default: EventEngine.xml
+EventInstanceFile = EventEngine.xml
+
+# Next Fight delay timer (in seconds).
+# Default: 10
+EventNextFightDelay = 10
 
 # Reward for winning player
-# Example: OvOEventReward = itemId,amount;itemId,amount;itemId,amount
-OvOEventReward =  57,10000;
+# Example: EventReward  = itemId,amount;itemId,amount;itemId,amount
+EventReward = 57,10000;
 
 # Reward for kill player
 # Example: AvAEventRewardKill = itemId,amount;itemId,amount;itemId,amount
-OvOEventRewardKill = 57,100;
+EventRewardKill = 57,100;
 
 # First Team - Name, Start/Death x,y,z location
 # Format: x,y,z
 # Example: 148695,46725,-3414
-OvOEventTeam1Coordinates = 148695,46725,-3414
+EventTeam1Coordinates = 148695,46725,-3414
 
 # Second Team - Name, Start/Death x,y,z location
 # Format: x,y,z
 # Example: 149999,46728,-3414
-OvOEventTeam2Coordinates = 149999,46728,-3414
+EventTeam2Coordinates = 149999,46728,-3414

--- a/dist/game/config/EventEngine/Survive.properties
+++ b/dist/game/config/EventEngine/Survive.properties
@@ -7,26 +7,30 @@
 
 # Enable/Disable SV Event
 # Default: False
-SVEventEnabled = False
+EventEnabled = False
+
+# Name of the instance file for events
+# Default: EventEngine.xml
+EventInstanceFile = EventEngine.xml
 
 # Reward for winning player
-# Example: SVEventReward = itemId,amount;itemId,amount;itemId,amount
-SVEventReward =  57,10000;
+# Example: EventReward  = itemId,amount;itemId,amount;itemId,amount
+EventReward = 57,10000;
 
 # Player spawn, Start/Death x,y,z location
 # Format: x,y,z
 # Example: 148695,46725,-3414
-SVEventCoordinatesPlayer = 148695,46725,-3414
+EventCoordinatesPlayer = 148695,46725,-3414
 
 # Mobs spawn, Start/Death x,y,z location
 # Format: x,y,z
 # Example: 149999,46728,-3414
-SVEventCoordinatesMobs = 149999,46728,-3414
+EventCoordinatesMobs = 149999,46728,-3414
 
 # ID of mobs to spawn
 # Default: 333800,333801
-SVEventMobsID = 333800,333801
+EventMobsID = 22839,22840
 
 # Number of mobs to increase by round
 # Default: 5
-SVEventMobsSpawnForStage = 5
+EventMobsSpawnForStage = 5

--- a/dist/game/config/EventEngine/TeamVsTeam.properties
+++ b/dist/game/config/EventEngine/TeamVsTeam.properties
@@ -7,22 +7,26 @@
 
 # Enable/Disable TvT Event
 # Default: True
-TvTEventEnabled = True
+EventEnabled = True
+
+# Name of the instance file for events
+# Default: EventEngine.xml
+EventInstanceFile = EventEngine.xml
 
 # Reward for winning player
-# Example: TvTEventReward = itemId,amount;itemId,amount;itemId,amount
-TvTEventReward =  57,10000;
+# Example: EventReward  = itemId,amount;itemId,amount;itemId,amount
+EventReward =  57,10000;
 
 # Reward for kill player
 # Example: TvTEventRewardKill = itemId,amount;itemId,amount;itemId,amount
-TvTEventRewardKill = 57,100;
+EventRewardKill = 57,100;
 
 # First Team - Name, Start/Death x,y,z location
 # Format: x,y,z
 # Example: 148695,46725,-3414
-TvTEventTeam1Coordinates = 148695,46725,-3414
+EventTeam1Coordinates = 148695,46725,-3414
 
 # Second Team - Name, Start/Death x,y,z location
 # Format: x,y,z
 # Example: 149999,46728,-3414
-TvTEventTeam2Coordinates = 149999,46728,-3414
+EventTeam2Coordinates = 149999,46728,-3414

--- a/dist/game/data/stats/npcs/custom/EventEngine.xml
+++ b/dist/game/data/stats/npcs/custom/EventEngine.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../xsd/npcs.xsd">
+	
+	<!-- Event Engine Manager -->
+	<npc id="36600" displayId="32226" name="Manager Event" usingServerSideName="true" title="Event Engine" usingServerSideTitle="true" type="L2Npc">
+		<collision>
+			<radius normal="11" />
+			<height normal="22.25" />
+		</collision>
+	</npc>
+	
+	<!-- Event Engine Flag -->
+	<npc id="36601" displayId="35062" name="Flag" usingServerSideName="true" title="BLUE" usingServerSideTitle="true" type="L2Npc">
+		<collision>
+			<radius normal="11" />
+			<height normal="22.25" />
+		</collision>
+	</npc>
+	<npc id="36602" displayId="35062" name="Flag" usingServerSideName="true" title="RED" usingServerSideTitle="true" type="L2Npc">
+		<collision>
+			<radius normal="11" />
+			<height normal="22.25" />
+		</collision>
+	</npc>
+	
+	<!-- Event Engine Holder -->
+	<npc id="36603" displayId="32027" name="Holder" usingServerSideName="true" title="BLUE" usingServerSideTitle="true" type="L2Npc">
+		<collision>
+			<radius normal="11" />
+			<height normal="22.25" />
+		</collision>
+	</npc>
+	<npc id="36604" displayId="32027" name="Holder" usingServerSideName="true" title="RED" usingServerSideTitle="true" type="L2Npc">
+		<collision>
+			<radius normal="11" />
+			<height normal="22.25" />
+		</collision>
+	</npc>
+</list>

--- a/java/net/sf/eventengine/datatables/BuffListData.java
+++ b/java/net/sf/eventengine/datatables/BuffListData.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -56,7 +55,7 @@ public class BuffListData implements IXmlReader
 	public void load()
 	{
 		parseDatapackFile("config/EventEngine/xml/buff_list.xml");
-		LOGGER.log(Level.INFO, getClass().getSimpleName() + ": Loaded: " + _buffList.size() + " Buffs.");
+		LOGGER.info("{}: Loaded {} Buffs.", getClass().getSimpleName(), _buffList.size());
 	}
 	
 	@Override

--- a/java/net/sf/eventengine/datatables/ConfigData.java
+++ b/java/net/sf/eventengine/datatables/ConfigData.java
@@ -32,71 +32,81 @@ import com.l2jserver.gameserver.model.holders.ItemHolder;
  */
 public class ConfigData
 {
+	// --------------------------------------------------
+	// Event Engine Property File Definitions
+	// --------------------------------------------------
 	private static final String EVENT_CONFIG = "./config/EventEngine/EventEngine.properties";
 	private static final String TVT_CONFIG = "./config/EventEngine/TeamVsTeam.properties";
 	private static final String AVA_CONFIG = "./config/EventEngine/AllVsAll.properties";
-	// private static final String CTF_CONFIG = "./config/EventEngine/CTF.properties";
+	private static final String CTF_CONFIG = "./config/EventEngine/CaptureTheFlag.properties";
 	private static final String OVO_CONFIG = "./config/EventEngine/OneVsOne.properties";
 	private static final String SURVIVE_CONFIG = "./config/EventEngine/Survive.properties";
 	
-	// lista de configs generales
-	
-	/** Definimos ID del npc del engine */
+	// -------------------------------------------------------------------------------
+	// Event Engine - Variable Definitions
+	// -------------------------------------------------------------------------------
 	public int NPC_MANAGER_ID;
-	/** Definimos el xml q usaremos para nuestras instancias. */
 	public String INSTANCE_FILE;
-	/** Definimos cada cuanto se ejecutara algun evento en hs */
 	public int EVENT_TASK;
-	/** Definimos si va a haber tiempo de votacion */
 	public boolean EVENT_VOTING_ENABLED;
-	/** Definimos el tiempo que durara el periodo de votacion */
 	public int EVENT_VOTING_TIME;
-	/** Definimos el tiempo que durara el periodo de registro */
 	public int EVENT_REGISTER_TIME;
-	/** Definimos el tiempo que durara cada evento en minutos */
 	public int EVENT_DURATION;
-	/** Definimos si permitimos o no el daño entre amigos. */
+	public int EVENT_TELEPORT_PLAYER_DELAY;
 	public boolean FRIENDLY_FIRE;
-	/** Definimos la cant de players maximo/minimo que podran participar */
 	public int MIN_PLAYERS_IN_EVENT;
 	public int MAX_PLAYERS_IN_EVENT;
-	/** Definimos el lvl maximo/minimo que podran participar de los eventos. */
 	public int MIN_LVL_IN_EVENT;
 	public int MAX_LVL_IN_EVENT;
-	/** Definimos la cantidad maxima de buffs q se podran usar */
 	public static int MAX_BUFF_COUNT;
 	
 	// -------------------------------------------------------------------------------
-	// Configs All Vs All
+	// Capture The Flag - Settings
+	// -------------------------------------------------------------------------------
+	public boolean CTF_EVENT_ENABLED;
+	public String CTF_INSTANCE_FILE;
+	public List<ItemHolder> CTF_REWARD_PLAYER_WIN = new ArrayList<>();
+	public Location CTF_COORDINATES_TEAM_RED;
+	public Location CTF_COORDINATES_TEAM_BLUE;
+	public int CTF_POINTS_CONQUER_FLAG;
+	public int CTF_POINTS_KILL;
+	
+	// -------------------------------------------------------------------------------
+	// All vs All - Settings
 	// -------------------------------------------------------------------------------
 	public boolean AVA_EVENT_ENABLED;
+	public String AVA_INSTANCE_FILE;
 	public List<ItemHolder> AVA_REWARD_PLAYER_WIN = new ArrayList<>();
 	public List<ItemHolder> AVA_REWARD_KILL_PLAYER = new ArrayList<>();
 	public Location AVA_COORDINATES_PLAYER;
 	
 	// -------------------------------------------------------------------------------
-	// Configs One Vs One
+	// One vs One - Settings
 	// -------------------------------------------------------------------------------
 	public boolean OVO_EVENT_ENABLED;
+	public String OVO_INSTANCE_FILE;
+	public int OVO_NEXT_FIGHT_DELAY;
 	public boolean OVO_REWARD_TEAM_TIE;
 	public List<ItemHolder> OVO_REWARD_PLAYER_WIN = new ArrayList<>();
 	public List<ItemHolder> OVO_REWARD_KILL_PLAYER = new ArrayList<>();
-	public Location OVO_COORDINATES_TEAM_1;
-	public Location OVO_COORDINATES_TEAM_2;
+	public Location OVO_COORDINATES_TEAM_RED;
+	public Location OVO_COORDINATES_TEAM_BLUE;
 	
 	// -------------------------------------------------------------------------------
-	// Configs Team Vs Team
+	// Team vs Team - Settings
 	// -------------------------------------------------------------------------------
 	public boolean TVT_EVENT_ENABLED;
+	public String TVT_INSTANCE_FILE;
 	public List<ItemHolder> TVT_REWARD_PLAYER_WIN = new ArrayList<>();
 	public List<ItemHolder> TVT_REWARD_KILL_PLAYER = new ArrayList<>();
-	public Location TVT_COORDINATES_TEAM_1;
-	public Location TVT_COORDINATES_TEAM_2;
+	public Location TVT_COORDINATES_TEAM_RED;
+	public Location TVT_COORDINATES_TEAM_BLUE;
 	
 	// -------------------------------------------------------------------------------
-	// Configs Survive
+	// Survive - Settings
 	// -------------------------------------------------------------------------------
 	public boolean SURVIVE_EVENT_ENABLED;
+	public String SURVIVE_INSTANCE_FILE;
 	public List<ItemHolder> SURVIVE_REWARD_PLAYER_WIN = new ArrayList<>();
 	public Location SURVIVE_COORDINATES_PLAYER;
 	public Location SURVIVE_COORDINATES_MOBS;
@@ -108,13 +118,18 @@ public class ConfigData
 		load();
 	}
 	
-	// Metodo encargado de leer los configs
+	/**
+	 * This class initializes all global variables for configuration.<br>
+	 * If the key doesn't appear in properties file, a default value is set by this class. {@link #CONFIGURATION_FILE} (properties file) for configuring your server.
+	 */
 	public void load()
 	{
+		// Properties Settings
 		EventPropertiesParser settings;
-		// ------------------------------------------------------------------------------------- //
+		
+		// -------------------------------------------------------------------------------------
 		// EventEngine.properties
-		// ------------------------------------------------------------------------------------- //
+		// -------------------------------------------------------------------------------------
 		settings = new EventPropertiesParser(EVENT_CONFIG);
 		NPC_MANAGER_ID = settings.getInt("EventParticipationNpcId", 36600);
 		EVENT_TASK = settings.getInt("EventInterval", 10);
@@ -122,53 +137,70 @@ public class ConfigData
 		EVENT_VOTING_TIME = settings.getInt("EventVotingTime", 10);
 		EVENT_REGISTER_TIME = settings.getInt("EventRegisterTime", 10);
 		EVENT_DURATION = settings.getInt("EventRunningTime", 10);
+		EVENT_TELEPORT_PLAYER_DELAY = settings.getInt("EventTeleportPlayerDelay", 10);
 		FRIENDLY_FIRE = settings.getBoolean("EventFriendlyFire", false);
 		MIN_PLAYERS_IN_EVENT = settings.getInt("EventMinPlayers", 2);
 		MAX_PLAYERS_IN_EVENT = settings.getInt("EventMaxPlayers", 20);
 		MIN_LVL_IN_EVENT = settings.getInt("EventMinPlayerLevel", 40);
 		MAX_LVL_IN_EVENT = settings.getInt("EventMaxPlayerLevel", 78);
-		INSTANCE_FILE = settings.getString("EventInstanceFile", "EventEngine.xml");
 		MAX_BUFF_COUNT = settings.getInt("EventMaxBuffCount", 5);
 		
-		// ------------------------------------------------------------------------------------- //
+		// -------------------------------------------------------------------------------------
+		// CaptureTheFlag.properties
+		// -------------------------------------------------------------------------------------
+		settings = new EventPropertiesParser(CTF_CONFIG);
+		CTF_INSTANCE_FILE = settings.getString("EventInstanceFile", "EventEngine.xml");
+		CTF_EVENT_ENABLED = settings.getBoolean("EventEnabled", false);
+		CTF_REWARD_PLAYER_WIN = settings.getItemHolderList("EventReward");
+		CTF_COORDINATES_TEAM_RED = settings.getLocation("EventTeam1Coordinates");
+		CTF_COORDINATES_TEAM_BLUE = settings.getLocation("EventTeam2Coordinates");
+		CTF_POINTS_CONQUER_FLAG = settings.getInt("EventPointsConquerFlag", 10);
+		CTF_POINTS_KILL = settings.getInt("EventPointsKill", 1);
+		
+		// -------------------------------------------------------------------------------------
 		// AllVsAll.properties
-		// ------------------------------------------------------------------------------------- //
+		// -------------------------------------------------------------------------------------
 		settings = new EventPropertiesParser(AVA_CONFIG);
-		AVA_EVENT_ENABLED = settings.getBoolean("AvAEventEnabled", false);
-		AVA_REWARD_PLAYER_WIN = settings.getItemHolderList("AvAEventReward");
-		AVA_REWARD_KILL_PLAYER = settings.getItemHolderList("AvAEventRewardKill");
-		AVA_COORDINATES_PLAYER = settings.getLocation("AvAEventCoordinates");
+		AVA_EVENT_ENABLED = settings.getBoolean("EventEnabled", false);
+		AVA_INSTANCE_FILE = settings.getString("EventInstanceFile", "EventEngine.xml");
+		AVA_REWARD_PLAYER_WIN = settings.getItemHolderList("EventReward");
+		AVA_REWARD_KILL_PLAYER = settings.getItemHolderList("EventRewardKill");
+		AVA_COORDINATES_PLAYER = settings.getLocation("EventCoordinates");
 		
-		// ------------------------------------------------------------------------------------- //
+		// -------------------------------------------------------------------------------------
 		// OneVsOne.properties
-		// ------------------------------------------------------------------------------------- //
+		// -------------------------------------------------------------------------------------
 		settings = new EventPropertiesParser(OVO_CONFIG);
-		OVO_EVENT_ENABLED = settings.getBoolean("OvOEventEnabled", false);
-		OVO_REWARD_PLAYER_WIN = settings.getItemHolderList("OvOEventReward");
-		OVO_REWARD_KILL_PLAYER = settings.getItemHolderList("OvOEventRewardKill");
-		OVO_COORDINATES_TEAM_1 = settings.getLocation("OvOEventTeam1Coordinates");
-		OVO_COORDINATES_TEAM_2 = settings.getLocation("OvOEventTeam2Coordinates");
+		OVO_EVENT_ENABLED = settings.getBoolean("EventEnabled", false);
+		OVO_INSTANCE_FILE = settings.getString("EventInstanceFile", "EventEngine.xml");
+		OVO_NEXT_FIGHT_DELAY = settings.getInt("EventNextFightDelay", 10);
+		OVO_REWARD_PLAYER_WIN = settings.getItemHolderList("EventReward");
+		OVO_REWARD_KILL_PLAYER = settings.getItemHolderList("EventRewardKill");
+		OVO_COORDINATES_TEAM_RED = settings.getLocation("EventTeam1Coordinates");
+		OVO_COORDINATES_TEAM_BLUE = settings.getLocation("EventTeam2Coordinates");
 		
-		// ------------------------------------------------------------------------------------- //
+		// -------------------------------------------------------------------------------------
 		// TeamVsTeam.properties
-		// ------------------------------------------------------------------------------------- //
+		// -------------------------------------------------------------------------------------
 		settings = new EventPropertiesParser(TVT_CONFIG);
-		TVT_EVENT_ENABLED = settings.getBoolean("TvTEventEnabled", false);
-		TVT_REWARD_PLAYER_WIN = settings.getItemHolderList("TvTEventReward");
-		TVT_REWARD_KILL_PLAYER = settings.getItemHolderList("TvTEventRewardKill");
-		TVT_COORDINATES_TEAM_1 = settings.getLocation("TvTEventTeam1Coordinates");
-		TVT_COORDINATES_TEAM_2 = settings.getLocation("TvTEventTeam2Coordinates");
+		TVT_EVENT_ENABLED = settings.getBoolean("EventEnabled", false);
+		TVT_INSTANCE_FILE = settings.getString("EventInstanceFile", "EventEngine.xml");
+		TVT_REWARD_PLAYER_WIN = settings.getItemHolderList("EventReward");
+		TVT_REWARD_KILL_PLAYER = settings.getItemHolderList("EventRewardKill");
+		TVT_COORDINATES_TEAM_RED = settings.getLocation("EventTeam1Coordinates");
+		TVT_COORDINATES_TEAM_BLUE = settings.getLocation("EventTeam2Coordinates");
 		
-		// ------------------------------------------------------------------------------------- //
+		// -------------------------------------------------------------------------------------
 		// Survive.properties
-		// ------------------------------------------------------------------------------------- //
+		// -------------------------------------------------------------------------------------
 		settings = new EventPropertiesParser(SURVIVE_CONFIG);
-		SURVIVE_EVENT_ENABLED = settings.getBoolean("SVEventEnabled", false);
-		SURVIVE_REWARD_PLAYER_WIN = settings.getItemHolderList("SVEventReward");
-		SURVIVE_COORDINATES_PLAYER = settings.getLocation("SVEventCoordinatesPlayer");
-		SURVIVE_COORDINATES_MOBS = settings.getLocation("SVEventCoordinatesMobs");
-		SURVIVE_MONSTERS_ID = settings.getListInteger("SVEventMobsID");
-		SURVIVE_MONSTER_SPAWN_FOR_STAGE = settings.getInt("SVEventMobsSpawnForStage", 5);
+		SURVIVE_EVENT_ENABLED = settings.getBoolean("EventEnabled", false);
+		SURVIVE_INSTANCE_FILE = settings.getString("EventInstanceFile", "EventEngine.xml");
+		SURVIVE_REWARD_PLAYER_WIN = settings.getItemHolderList("EventReward");
+		SURVIVE_COORDINATES_PLAYER = settings.getLocation("EventCoordinatesPlayer");
+		SURVIVE_COORDINATES_MOBS = settings.getLocation("EventCoordinatesMobs");
+		SURVIVE_MONSTERS_ID = settings.getListInteger("EventMobsID");
+		SURVIVE_MONSTER_SPAWN_FOR_STAGE = settings.getInt("EventMobsSpawnForStage", 5);
 	}
 	
 	public static ConfigData getInstance()

--- a/java/net/sf/eventengine/datatables/EventData.java
+++ b/java/net/sf/eventengine/datatables/EventData.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 
 import net.sf.eventengine.events.AllVsAll;
+import net.sf.eventengine.events.CaptureTheFlag;
 import net.sf.eventengine.events.OneVsOne;
 import net.sf.eventengine.events.Survive;
 import net.sf.eventengine.events.TeamVsTeam;
@@ -54,6 +55,12 @@ public class EventData
 		{
 			_eventList.add(TeamVsTeam.class);
 			_eventMap.put(TeamVsTeam.class.getSimpleName(), TeamVsTeam.class);
+		}
+		
+		if (ConfigData.getInstance().CTF_EVENT_ENABLED)
+		{
+			_eventList.add(CaptureTheFlag.class);
+			_eventMap.put(CaptureTheFlag.class.getSimpleName(), CaptureTheFlag.class);
 		}
 	}
 	

--- a/java/net/sf/eventengine/events/CaptureTheFlag.java
+++ b/java/net/sf/eventengine/events/CaptureTheFlag.java
@@ -20,27 +20,51 @@ package net.sf.eventengine.events;
 
 import net.sf.eventengine.datatables.ConfigData;
 import net.sf.eventengine.enums.EventState;
+import net.sf.eventengine.enums.PlayerColorType;
 import net.sf.eventengine.handler.AbstractEvent;
 import net.sf.eventengine.holder.PlayerHolder;
+import net.sf.eventengine.util.EventUtil;
 
+import com.l2jserver.gameserver.datatables.ItemTable;
 import com.l2jserver.gameserver.enums.Team;
 import com.l2jserver.gameserver.model.actor.L2Character;
 import com.l2jserver.gameserver.model.actor.L2Npc;
+import com.l2jserver.gameserver.model.instancezone.InstanceWorld;
+import com.l2jserver.gameserver.model.itemcontainer.Inventory;
 import com.l2jserver.gameserver.model.items.L2Item;
+import com.l2jserver.gameserver.model.items.L2Weapon;
+import com.l2jserver.gameserver.model.items.instance.L2ItemInstance;
 import com.l2jserver.gameserver.model.skills.Skill;
+import com.l2jserver.gameserver.network.clientpackets.Say2;
 
 /**
  * @author fissban
  */
 public class CaptureTheFlag extends AbstractEvent
 {
+	// Flags
+	private static final int BLUE_FLAG = 36601;
+	private static final int RED_FLAG = 36602;
+	// Holder
+	private static final int BLUE_HOLDER = 36603;
+	private static final int RED_HOLDER = 36604;
+	// FlagItem
+	private static final int FLAG_ITEM = 6718;
+	// Points to conquer the flag
+	private final int POINTS_CONQUER_FLAG = ConfigData.getInstance().CTF_POINTS_CONQUER_FLAG;
+	private final int POINTS_KILL = ConfigData.getInstance().CTF_POINTS_KILL;
+	// Points that each team.
+	private int _pointsRed = 0;
+	private int _pointsBlue = 0;
+	// Radius spawn
+	private static final int RADIUS_SPAWN_PLAYER = 100;
+	
 	public CaptureTheFlag()
 	{
 		super();
-		
-		// Definimos los spawns de cada team
-		setTeamSpawn(Team.RED, ConfigData.getInstance().TVT_COORDINATES_TEAM_1);
-		setTeamSpawn(Team.BLUE, ConfigData.getInstance().TVT_COORDINATES_TEAM_2);
+		setInstanceFile(ConfigData.getInstance().CTF_INSTANCE_FILE);
+		setTeamSpawn(Team.RED, ConfigData.getInstance().CTF_COORDINATES_TEAM_RED);
+		setTeamSpawn(Team.BLUE, ConfigData.getInstance().CTF_COORDINATES_TEAM_BLUE);
 	}
 	
 	@Override
@@ -49,58 +73,363 @@ public class CaptureTheFlag extends AbstractEvent
 		switch (state)
 		{
 			case START:
-				prepareToStart(); // Metodo general
-				// createTeam();
-				teleportAllPlayers();
+				prepareToStart();
+				createTeams();
+				spawnFlagsAndHolders();
+				teleportAllPlayers(RADIUS_SPAWN_PLAYER);
 				break;
 			
 			case FIGHT:
-				prepareToFight(); // Metodo general
+				prepareToFight();
 				break;
 			
 			case END:
-				// giveRewardsTeams();
-				prepareToEnd(); // Metodo general
+				giveRewardsTeams();
+				prepareToEnd();
 				break;
 		}
-		
 	}
 	
 	@Override
 	public void onInteract(PlayerHolder player, L2Npc npc)
 	{
-		// TODO Auto-generated method stub
+		switch (npc.getId())
+		{
+			case BLUE_FLAG:
+				if (player.getPcInstance().getTeam() == Team.RED)
+				{
+					// We equip flag
+					equipFlag(player);
+					// We remove the flag from his position
+					removeNpc(npc);
+					// We announced that a flag was taken
+					EventUtil.announceToAllPlayersInEvent(Say2.SCREEN_ANNOUNCE, "El equipo rojo acaba de tomar la bandera");
+				}
+				break;
+			
+			case RED_FLAG:
+				if (player.getPcInstance().getTeam() == Team.BLUE)
+				{
+					// We equip flag
+					equipFlag(player);
+					// We remove the flag from his position
+					removeNpc(npc);
+					// We announced that a flag was taken
+					EventUtil.announceToAllPlayersInEvent(Say2.SCREEN_ANNOUNCE, "El equipo azul acaba de tomar la bandera");
+				}
+				break;
+			
+			case BLUE_HOLDER:
+				if (player.getPcInstance().getTeam() == Team.BLUE)
+				{
+					if (hasFlag(player))
+					{
+						// We increased the points
+						_pointsBlue += POINTS_CONQUER_FLAG;
+						// Remove the flag character
+						unequiFlag(player);
+						// We created the flag again
+						addEventNpc(RED_FLAG, ConfigData.getInstance().CTF_COORDINATES_TEAM_RED, Team.RED, getInstancesWorlds().get(0).getInstanceId());
+						// We announced that a flag was taken
+						EventUtil.announceToAllPlayersInEvent(Say2.SCREEN_ANNOUNCE, "El equipo azul acaba de conquistar la bandera del equipo enemigo");
+						// Show points of each team
+						showPoint();
+					}
+				}
+				break;
+			
+			case RED_HOLDER:
+				if (player.getPcInstance().getTeam() == Team.RED)
+				{
+					if (hasFlag(player))
+					{
+						// We increased the points
+						_pointsRed += POINTS_CONQUER_FLAG;
+						// Remove the flag character
+						unequiFlag(player);
+						// We created the flag again
+						addEventNpc(BLUE_FLAG, ConfigData.getInstance().CTF_COORDINATES_TEAM_BLUE, Team.BLUE, getInstancesWorlds().get(0).getInstanceId());
+						// We announced that a flag was taken
+						EventUtil.announceToAllPlayersInEvent(Say2.SCREEN_ANNOUNCE, "El equipo rojo acaba de conquistar la bandera del equipo enemigo");
+						// Show points of each team
+						showPoint();
+					}
+				}
+				break;
+		}
 	}
+	
+	// -------------------------------------------------------------------------------------
+	// LISTENERS
+	// -------------------------------------------------------------------------------------
 	
 	@Override
 	public void onKill(PlayerHolder player, L2Character target)
 	{
-		// TODO Auto-generated method stub
+		PlayerHolder targetEvent = getEventPlayer(target);
+		
+		if (hasFlag(targetEvent))
+		{
+			// Remove the flag character
+			unequiFlag(targetEvent);
+			// Drop flag.
+			dropFlag(targetEvent);
+		}
+		
+		// We increased the team's points.
+		switch (player.getPcInstance().getTeam())
+		{
+			case RED:
+				_pointsRed += POINTS_KILL;
+				break;
+			case BLUE:
+				_pointsBlue += POINTS_KILL;
+				break;
+		}
+		
+		showPoint();
 	}
 	
 	@Override
 	public void onDeath(PlayerHolder player)
 	{
-		// TODO Auto-generated method stub
+		giveResurrectPlayer(player, ConfigData.getInstance().EVENT_TELEPORT_PLAYER_DELAY, RADIUS_SPAWN_PLAYER);
 	}
 	
 	@Override
 	public boolean onAttack(PlayerHolder player, L2Character target)
 	{
-		// TODO Auto-generated method stub
 		return false;
 	}
 	
 	@Override
 	public boolean onUseSkill(PlayerHolder player, L2Character target, Skill skill)
 	{
-		// TODO Auto-generated method stub
 		return false;
 	}
 	
 	@Override
 	public boolean onUseItem(PlayerHolder player, L2Item item)
 	{
+		if (item.getId() == FLAG_ITEM)
+		{
+			return true;
+		}
+		
+		if (hasFlag(player) && item instanceof L2Weapon)
+		{
+			return true;
+		}
+		
 		return false;
+	}
+	
+	@Override
+	public void onLogout(PlayerHolder player)
+	{
+		if (hasFlag(player))
+		{
+			// Remove the flag character
+			unequiFlag(player);
+			dropFlag(player);
+		}
+	}
+	
+	// -------------------------------------------------------------------------------------
+	// OTHERS METHODS
+	// -------------------------------------------------------------------------------------
+	
+	/**
+	 * Spawn flags and holders
+	 */
+	private void spawnFlagsAndHolders()
+	{
+		// red
+		int x, y, z;
+		x = ConfigData.getInstance().CTF_COORDINATES_TEAM_RED.getX();
+		y = ConfigData.getInstance().CTF_COORDINATES_TEAM_RED.getY();
+		z = ConfigData.getInstance().CTF_COORDINATES_TEAM_RED.getZ();
+		addEventNpc(RED_FLAG, x - 100, y, z, 0, Team.RED, false, getInstancesWorlds().get(0).getInstanceId());
+		addEventNpc(RED_HOLDER, x - 200, y, z, 0, Team.RED, false, getInstancesWorlds().get(0).getInstanceId());
+		// blue
+		x = ConfigData.getInstance().CTF_COORDINATES_TEAM_BLUE.getX();
+		y = ConfigData.getInstance().CTF_COORDINATES_TEAM_BLUE.getY();
+		z = ConfigData.getInstance().CTF_COORDINATES_TEAM_BLUE.getZ();
+		addEventNpc(BLUE_FLAG, x + 100, y, z, 0, Team.BLUE, false, getInstancesWorlds().get(0).getInstanceId());
+		addEventNpc(BLUE_HOLDER, x + 200, y, z, 0, Team.BLUE, false, getInstancesWorlds().get(0).getInstanceId());
+	}
+	
+	/**
+	 * We all players who are at the event and generate the teams
+	 */
+	private void createTeams()
+	{
+		// We create the instance and the world
+		InstanceWorld world = createNewInstanceWorld();
+		
+		int aux = 0;
+		for (PlayerHolder player : getAllEventPlayers())
+		{
+			if ((aux % 2) == 0)
+			{
+				// Adjust the color of the title and the title character.
+				player.getPcInstance().setTeam(Team.BLUE);
+				player.setNewColorTitle(PlayerColorType.BLUE);
+				player.setNewTitle("[ BLUE ]");
+			}
+			else
+			{
+				// Adjust the color of the title and the title character.
+				player.getPcInstance().setTeam(Team.RED);
+				player.setNewColorTitle(PlayerColorType.RED);
+				player.setNewTitle("[ RED ]");
+			}
+			
+			// We add the character to the world and then be teleported
+			world.addAllowed(player.getPcInstance().getObjectId());
+			// We update the character in front of him around and himself
+			player.getPcInstance().updateAndBroadcastStatus(2);
+			// Adjust the instance that owns the character
+			player.setDinamicInstanceId(world.getInstanceId());
+			
+			aux++;
+		}
+	}
+	
+	/**
+	 * We deliver rewards.
+	 */
+	private void giveRewardsTeams()
+	{
+		if (getAllEventPlayers().isEmpty())
+		{
+			return;
+		}
+		
+		Team teamWinner = getWinTeam();
+		
+		for (PlayerHolder player : getAllEventPlayers())
+		{
+			// FIXME podriamos crear un metodo especificamente para esto pero aprobechamos el recorrido del for aqui!
+			if (hasFlag(player))
+			{
+				// Remove the flag character
+				unequiFlag(player);
+			}
+			
+			if (teamWinner == Team.NONE)
+			{
+				// Announcing the outcome of the event
+				EventUtil.sendEventScreenMessage(player, "El evento resulto en un empate entre ambos teams!");
+			}
+			else
+			{
+				// Announcing the outcome of the event
+				EventUtil.sendEventScreenMessage(player, "Equipo ganador -> " + teamWinner.getClass().getCanonicalName() + "!");
+				
+				// We deliver rewards
+				if (player.getPcInstance().getTeam() == teamWinner)
+				{
+					giveItems(player, ConfigData.getInstance().CTF_REWARD_PLAYER_WIN);
+				}
+			}
+		}
+	}
+	
+	/**
+	 * We get the winning team<br>
+	 */
+	private Team getWinTeam()
+	{
+		Team ganador;
+		
+		if (_pointsRed == _pointsBlue)
+		{
+			ganador = Team.NONE;
+		}
+		else if (_pointsRed > _pointsBlue)
+		{
+			ganador = Team.RED;
+		}
+		else
+		{
+			ganador = Team.BLUE;
+		}
+		
+		return ganador;
+	}
+	
+	/**
+	 * Show on screen the number of points that each team
+	 */
+	private void showPoint()
+	{
+		for (PlayerHolder ph : getAllEventPlayers())
+		{
+			EventUtil.sendEventScreenMessage(ph, "RED " + _pointsRed + " | " + _pointsBlue + " BLUE", 10000);
+			// ph.getPcInstance().sendPacket(new EventParticipantStatus(_pointsRed, _pointsBlue));
+		}
+	}
+	
+	/**
+	 * Check if a character has a flag
+	 * @param ph
+	 * @return
+	 */
+	private boolean hasFlag(PlayerHolder ph)
+	{
+		L2ItemInstance item = ph.getPcInstance().getInventory().getPaperdollItem(Inventory.PAPERDOLL_RHAND);
+		
+		if (item != null && item.getId() == FLAG_ITEM)
+		{
+			return true;
+		}
+		
+		return false;
+	}
+	
+	/**
+	 * We equip a character with a flag
+	 * @param ph
+	 */
+	private void equipFlag(PlayerHolder ph)
+	{
+		L2ItemInstance flag = ItemTable.getInstance().createItem("", FLAG_ITEM, 1, ph.getPcInstance(), null);
+		if (flag != null)
+		{
+			ph.getPcInstance().useEquippableItem(flag, true);
+		}
+	}
+	
+	/**
+	 * We remove the flag of a character
+	 * @param ph
+	 */
+	private void unequiFlag(PlayerHolder ph)
+	{
+		L2ItemInstance flag = ph.getPcInstance().getInventory().getPaperdollItem(Inventory.PAPERDOLL_RHAND);
+		if (flag != null)
+		{
+			ph.getPcInstance().useEquippableItem(flag, true);
+		}
+	}
+	
+	private void dropFlag(PlayerHolder player)
+	{
+		switch (player.getPcInstance().getTeam())
+		{
+			case RED:
+				// New spawn for blue flag
+				addEventNpc(BLUE_FLAG, player.getPcInstance().getLocation(), Team.BLUE, getInstancesWorlds().get(0).getInstanceId());
+				// We announced that a flag was taken
+				EventUtil.announceToAllPlayersInEvent(Say2.SCREEN_ANNOUNCE, "El personaje " + player.getPcInstance().getName() + "ha dropeado la bandera AZUL");
+				break;
+			case BLUE:
+				// New spawn for the red flag
+				addEventNpc(RED_FLAG, player.getPcInstance().getLocation(), Team.RED, getInstancesWorlds().get(0).getInstanceId());
+				// We announced that a flag was taken
+				EventUtil.announceToAllPlayersInEvent(Say2.SCREEN_ANNOUNCE, "El personaje " + player.getPcInstance().getName() + "ha dropeado la bandera RED");
+				break;
+		}
 	}
 }

--- a/java/net/sf/eventengine/events/TeamVsTeam.java
+++ b/java/net/sf/eventengine/events/TeamVsTeam.java
@@ -21,7 +21,6 @@ package net.sf.eventengine.events;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.sf.eventengine.EventEngineManager;
 import net.sf.eventengine.datatables.ConfigData;
 import net.sf.eventengine.enums.EventState;
 import net.sf.eventengine.enums.PlayerColorType;
@@ -42,17 +41,19 @@ import com.l2jserver.gameserver.model.skills.Skill;
  */
 public class TeamVsTeam extends AbstractEvent
 {
-	// Puntos que tiene cada team.
+	// Points that each team.
 	private int _pointsRed = 0;
 	private int _pointsBlue = 0;
+	
+	// Radius spawn
+	private static final int RADIUS_SPAWN_PLAYER = 300;
 	
 	public TeamVsTeam()
 	{
 		super();
-		
-		// Definimos los spawns de cada team
-		setTeamSpawn(Team.RED, ConfigData.getInstance().TVT_COORDINATES_TEAM_1);
-		setTeamSpawn(Team.BLUE, ConfigData.getInstance().TVT_COORDINATES_TEAM_2);
+		setInstanceFile(ConfigData.getInstance().TVT_INSTANCE_FILE);
+		setTeamSpawn(Team.RED, ConfigData.getInstance().TVT_COORDINATES_TEAM_RED);
+		setTeamSpawn(Team.BLUE, ConfigData.getInstance().TVT_COORDINATES_TEAM_BLUE);
 	}
 	
 	@Override
@@ -61,25 +62,28 @@ public class TeamVsTeam extends AbstractEvent
 		switch (state)
 		{
 			case START:
-				prepareToStart(); // Metodo general
+				prepareToStart();
 				createTeams();
-				teleportAllPlayers();
+				teleportAllPlayers(RADIUS_SPAWN_PLAYER);
 				break;
 			
 			case FIGHT:
-				prepareToFight(); // Metodo general
+				prepareToFight();
 				showPoint();
 				break;
 			
 			case END:
 				// showResult();
 				giveRewardsTeams();
-				prepareToEnd(); // Metodo general
+				prepareToEnd();
 				break;
 		}
 	}
 	
-	// LISTENERS ------------------------------------------------------
+	// -------------------------------------------------------------------------------------
+	// LISTENERS
+	// -------------------------------------------------------------------------------------
+	
 	@Override
 	public boolean onUseSkill(PlayerHolder player, L2Character target, Skill skill)
 	{
@@ -95,7 +99,6 @@ public class TeamVsTeam extends AbstractEvent
 	@Override
 	public void onKill(PlayerHolder player, L2Character target)
 	{
-		// Incrementamos los puntos del team.
 		switch (player.getPcInstance().getTeam())
 		{
 			case RED:
@@ -112,9 +115,7 @@ public class TeamVsTeam extends AbstractEvent
 	@Override
 	public void onDeath(PlayerHolder player)
 	{
-		giveResurrectPlayer(player, 10);
-		// incrementamos en uno la cantidad de muertes del personaje
-		// solo es usado al final del evento para mostrar los resultados
+		giveResurrectPlayer(player, ConfigData.getInstance().EVENT_TELEPORT_PLAYER_DELAY, RADIUS_SPAWN_PLAYER);
 		player.increaseDeaths();
 	}
 	
@@ -130,40 +131,47 @@ public class TeamVsTeam extends AbstractEvent
 		return false;
 	}
 	
-	// METODOS VARIOS -------------------------------------------------
+	@Override
+	public void onLogout(PlayerHolder player)
+	{
+		// empty
+	}
+	
+	// -------------------------------------------------------------------------------------
+	// OTHERS METHODS
+	// -------------------------------------------------------------------------------------
 	
 	/**
-	 * Tomamos todos los players que estan registrados en el evento y generamos los teams
+	 * We all players who are at the event and generate the teams
 	 */
 	private void createTeams()
 	{
-		// Creamos la instancia y el mundo
-		InstanceWorld world = EventEngineManager.getInstance().createNewInstanceWorld();
+		// We create the instance and the world
+		InstanceWorld world = createNewInstanceWorld();
 		
 		int aux = 0;
-		
 		for (PlayerHolder player : getAllEventPlayers())
 		{
 			if ((aux % 2) == 0)
 			{
-				// Ajustamos el color del titulo y el titulo del personaje.
+				// Adjust the color of the title and the title character.
 				player.getPcInstance().setTeam(Team.BLUE);
 				player.setNewColorTitle(PlayerColorType.BLUE);
 				player.setNewTitle("[ BLUE ]");
 			}
 			else
 			{
-				// Ajustamos el color del titulo y el titulo del personaje.
+				// Adjust the color of the title and the title character.
 				player.getPcInstance().setTeam(Team.RED);
 				player.setNewColorTitle(PlayerColorType.RED);
 				player.setNewTitle("[ RED ]");
 			}
 			
-			// Agregamos el personaje al mundo para luego ser teletransportado
+			// We add the character to the world and then be teleported
 			world.addAllowed(player.getPcInstance().getObjectId());
-			// Actualizamos al personaje frente a lo de su alrededor y a si mismo
+			// Character status update
 			player.getPcInstance().updateAndBroadcastStatus(2);
-			// Ajustamos la instancia a al que perteneceran los personaje
+			// Adjust the instance which will own the character
 			player.setDinamicInstanceId(world.getInstanceId());
 			
 			aux++;
@@ -171,37 +179,31 @@ public class TeamVsTeam extends AbstractEvent
 	}
 	
 	/**
-	 * Entregamos los rewards, por el momento solo tenemos soporte para 1 o 2 teams.
+	 * Entregamos los rewards
 	 */
 	private void giveRewardsTeams()
 	{
-		if (EventEngineManager.getInstance().isEmptyRegisteredPlayers())
+		if (getAllEventPlayers().isEmpty())
 		{
 			return;
 		}
 		
-		Team ganador = getWinTeam();
+		Team teamWinner = getWinTeam();
 		
 		for (PlayerHolder player : getAllEventPlayers())
 		{
-			if (ganador == Team.NONE)
+			if (teamWinner == Team.NONE)
 			{
-				// Anunciamos el resultado del evento
+				// Send Message
 				EventUtil.sendEventScreenMessage(player, "El evento resulto en un empate entre ambos teams!");
-				
-				// Entregamos los rewards
-				if (ConfigData.getInstance().OVO_REWARD_TEAM_TIE)
-				{
-					giveItems(player, ConfigData.getInstance().TVT_REWARD_PLAYER_WIN);
-				}
 			}
 			else
 			{
-				// Anunciamos el resultado del evento
-				EventUtil.sendEventScreenMessage(player, "Equipo ganador -> " + ganador.getClass().getCanonicalName() + "!");
+				// Send Message
+				EventUtil.sendEventScreenMessage(player, "Equipo ganador -> " + teamWinner.toString() + "!");
 				
 				// Entregamos los rewards
-				if (player.getPcInstance().getTeam() == ganador)
+				if (player.getPcInstance().getTeam() == teamWinner)
 				{
 					giveItems(player, ConfigData.getInstance().TVT_REWARD_PLAYER_WIN);
 				}
@@ -211,12 +213,10 @@ public class TeamVsTeam extends AbstractEvent
 	}
 	
 	/**
-	 * Pequeño codigo para obtener al team ganador<br>
-	 * Solo es usado para ahorrar codigo.
+	 * Small code for the winning team<br>
 	 */
 	private Team getWinTeam()
 	{
-		// Si ambos equipos tienen la misma cant de puntos creo q lo justo es q ambos son perdedores :P
 		Team ganador;
 		
 		if (_pointsRed == _pointsBlue)
@@ -236,12 +236,10 @@ public class TeamVsTeam extends AbstractEvent
 	}
 	
 	/**
-	 * Mostramos por pantalla la canidad de puntos q tiene cada team
+	 * Show on screen the number of points that each team
 	 */
 	private void showPoint()
 	{
-		// Enviamos por pantalla los puntajes a todos en el evento
-		
 		for (PlayerHolder ph : getAllEventPlayers())
 		{
 			EventUtil.sendEventScreenMessage(ph, "RED " + _pointsRed + " | " + _pointsBlue + " BLUE", 10000);
@@ -250,7 +248,7 @@ public class TeamVsTeam extends AbstractEvent
 	}
 	
 	/**
-	 * Creamos listados con todos los participantes y le enviamos a cada uno los resultados finales del evento
+	 * Create lists with all participants and send to each final results of the event
 	 */
 	private void showResult()
 	{
@@ -270,7 +268,6 @@ public class TeamVsTeam extends AbstractEvent
 			}
 		}
 		
-		// Enviamos a todos los resultados finales del evento
 		for (PlayerHolder ph : getAllEventPlayers())
 		{
 			ph.getPcInstance().sendPacket(new EventParticipantStatus(_pointsRed, teamBlue, _pointsBlue, teamRed));


### PR DESCRIPTION
- The world instances now are handled by event instance
- Capture the Flag reworked
- One vs One reworked
- Documentation (comments) of all events translated.
- Fix: The npcs during events weren't removed when their event finished.
- Now, we can define the mob/npc team when the event spawns them.
- Before starting the event, it validates the player's state (olympiad, duel, spectator mode).
- ListenerOnKill works with playables and npcs.
- More functions for listenerOnLogout.
- Improvements to teleport players outside instance when the event finishs.
- Radius parameter added to teleport method.
- Now the player is revived before teleporting him.
- Add Spawn/Respawn delay timer (in seconds).
- Add EventNextFightDelay, for OvO Event.
- Add private static final int in events for Radius spawn.
- Up changes of @luksdlt92.
- Up diff.
- Sync with the last revision of l2j-server (LOGGER and class).
