### PR TITLE
Multiple locations

### DIFF
--- a/dist/game/config/EventEngine/AllVsAll.properties
+++ b/dist/game/config/EventEngine/AllVsAll.properties
@@ -46,4 +46,4 @@ EventRewardFameKill = 10
 # Player spawn, Start/Death x,y,z location
 # Format: x,y,z
 # Default: 149470,46709,-3408
-EventTeamCoordinates = 149470,46709,-3408
+EventTeamCoordinates = 150342,45917,-3411;150278,47586,-3413;148679,47576,-3413;148675,45975,-3411

--- a/dist/game/config/EventEngine/CaptureTheFlag.properties
+++ b/dist/game/config/EventEngine/CaptureTheFlag.properties
@@ -66,9 +66,8 @@ EventPointsKill = 1
 EventCountTeam = 2
 
 # Lugar a donde seran teletransportados los equipos.
-# La cantidad de coordenadas debe coincidir con la cantidad de equipos definidos.
+# La cantidad de grupo de coordenadas debe coincidir con la cantidad de equipos definidos.
 # Las coordendas se definiran en este orden:
 # -> RED,BLUE,PINK,ROSE_PINK,LEMON_YELOOW,LILAC,COBAL_VIOLET,MINT_GREEN,PEACOCK_GREEN,YELLOW_OCHRE,CHOCOLATE,SILVER
-# Se deberan definir cordenadas x,y,z para cada equipo usando el caracter "," para separar dichas cordenadas
-# y entre equipos se usara el caracter ";"
-EventTeamCoordinates = 148384,46712,-3411;150549,46712,-3411
+# Los grupos de coordenadas estan separados por '#', dentro de cada grupo las coordenadas se separan por ';'
+EventTeamCoordinates = 148695,46725,-3414;148687,46964,-3413;148682,46576,-3413#149999,46728,-3414;149989,47065,-3415;149975,46468,-3415

--- a/dist/game/config/EventEngine/OneVsOne.properties
+++ b/dist/game/config/EventEngine/OneVsOne.properties
@@ -53,6 +53,5 @@ EventCountTeam = 2
 # La cantidad de coordenadas debe coincidir con la cantidad de equipos definidos.
 # Las coordendas se definiran en este orden:
 # -> RED,BLUE,PINK,ROSE_PINK,LEMON_YELOOW,LILAC,COBAL_VIOLET,MINT_GREEN,PEACOCK_GREEN,YELLOW_OCHRE,CHOCOLATE,SILVER
-# Se deberan definir cordenadas x,y,z para cada equipo usando el caracter "," para separar dichas cordenadas
-# y entre equipos se usara el caracter ";"
-EventTeamCoordinates = 148384,46712,-3411;150549,46712,-3411
+# Se deberan definir cordenadas x,y,z para cada equipo, separando las mismas por medio de '#'
+EventTeamCoordinates = 148384,46712,-3411#150549,46712,-3411

--- a/dist/game/config/EventEngine/TeamVsTeam.properties
+++ b/dist/game/config/EventEngine/TeamVsTeam.properties
@@ -48,9 +48,8 @@ EventRewardFameKill = 10
 EventCountTeam = 2
 
 # Lugar a donde seran teletransportados los equipos.
-# La cantidad de coordenadas debe coincidir con la cantidad de equipos definidos.
+# La cantidad de grupos de coordenadas debe coincidir con la cantidad de equipos definidos.
 # Las coordendas se definiran en este orden:
 # -> RED,BLUE,PINK,ROSE_PINK,LEMON_YELOOW,LILAC,COBAL_VIOLET,MINT_GREEN,PEACOCK_GREEN,YELLOW_OCHRE,CHOCOLATE,SILVER
-# Se deberan definir cordenadas x,y,z para cada equipo usando el caracter "," para separar dichas cordenadas
-# y entre equipos se usara el caracter ";"
-EventTeamCoordinates = 148384,46712,-3411;150549,46712,-3411
+# Los grupos de coordenadas estan separados por '#', dentro de cada grupo las coordenadas se separan por ';'
+EventTeamCoordinates = 148695,46725,-3414;148687,46964,-3413;148682,46576,-3413#149999,46728,-3414;149989,47065,-3415;149975,46468,-3415

--- a/java/net/sf/eventengine/datatables/ConfigData.java
+++ b/java/net/sf/eventengine/datatables/ConfigData.java
@@ -22,10 +22,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
+import net.sf.eventengine.model.Locations;
+import net.sf.eventengine.util.EventPropertiesParser;
+
 import com.l2jserver.gameserver.model.Location;
 import com.l2jserver.gameserver.model.holders.ItemHolder;
-
-import net.sf.eventengine.util.EventPropertiesParser;
 
 /**
  * Load the config from "properties"
@@ -76,7 +77,7 @@ public class ConfigData
 	public int CTF_POINTS_CONQUER_FLAG;
 	public int CTF_POINTS_KILL;
 	public int CTF_COUNT_TEAM;
-	public List<Location> CTF_COORDINATES_TEAM;
+	public ArrayList<Locations> CTF_COORDINATES_TEAM;
 	
 	// -------------------------------------------------------------------------------
 	// Configs All Vs All
@@ -90,8 +91,7 @@ public class ConfigData
 	public int AVA_REWARD_PVP_KILLER;
 	public boolean AVA_REWARD_FAME_KILLER_ENABLED;
 	public int AVA_REWARD_FAME_KILLER;
-	
-	public List<Location> AVA_COORDINATES_TEAM;
+	public ArrayList<Locations> AVA_COORDINATES_TEAM;
 	
 	// -------------------------------------------------------------------------------
 	// Configs One Vs One
@@ -106,7 +106,7 @@ public class ConfigData
 	public boolean OVO_REWARD_FAME_KILLER_ENABLED;
 	public int OVO_REWARD_FAME_KILLER;
 	public int OVO_COUNT_TEAM;
-	public List<Location> OVO_COORDINATES_TEAM;
+	public ArrayList<Locations> OVO_COORDINATES_TEAM;
 	
 	// -------------------------------------------------------------------------------
 	// Configs Team Vs Team
@@ -121,7 +121,7 @@ public class ConfigData
 	public boolean TVT_REWARD_FAME_KILLER_ENABLED;
 	public int TVT_REWARD_FAME_KILLER;
 	public int TVT_COUNT_TEAM;
-	public List<Location> TVT_COORDINATES_TEAM;
+	public ArrayList<Locations> TVT_COORDINATES_TEAM;
 	
 	// -------------------------------------------------------------------------------
 	// Configs Survive
@@ -133,7 +133,7 @@ public class ConfigData
 	public List<Integer> SURVIVE_MONSTERS_ID = new ArrayList<>();
 	public int SURVIVE_MONSTER_SPAWN_FOR_STAGE;
 	public int SURVIVE_COUNT_TEAM;
-	public List<Location> SURVIVE_COORDINATES_TEAM;
+	public ArrayList<Locations> SURVIVE_COORDINATES_TEAM;
 	
 	public ConfigData()
 	{
@@ -180,9 +180,9 @@ public class ConfigData
 		CTF_REWARD_FAME_KILLER = settings.getInt("EventRewardFameKill", 10);
 		CTF_POINTS_CONQUER_FLAG = settings.getInt("EventPointsConquerFlag", 10);
 		CTF_POINTS_KILL = settings.getInt("EventPointsKill", 1);
-		CTF_COORDINATES_TEAM = settings.getLocationList("EventTeamCoordinates");
+		CTF_COORDINATES_TEAM = settings.getMultipleLocationList("EventTeamCoordinates");
 		CTF_COUNT_TEAM = settings.getInt("EventCountTeam", 2);
-		checkTeamAndSpawn("CaptureTheFlag", CTF_COORDINATES_TEAM, CTF_COUNT_TEAM);
+		checkTeamAndMultipleSpawn("CaptureTheFlag", CTF_COORDINATES_TEAM, CTF_COUNT_TEAM);
 		
 		// ------------------------------------------------------------------------------------- //
 		// AllVsAll.properties
@@ -198,7 +198,7 @@ public class ConfigData
 		AVA_REWARD_FAME_KILLER_ENABLED = settings.getBoolean("EventRewardFameKillEnabled", false);
 		AVA_REWARD_FAME_KILLER = settings.getInt("EventRewardFameKill", 10);
 		
-		AVA_COORDINATES_TEAM = settings.getLocationList("EventTeamCoordinates");
+		AVA_COORDINATES_TEAM = settings.getMultipleLocationList("EventTeamCoordinates");
 		
 		// ------------------------------------------------------------------------------------- //
 		// OneVsOne.properties
@@ -214,8 +214,8 @@ public class ConfigData
 		OVO_REWARD_FAME_KILLER_ENABLED = settings.getBoolean("EventRewardFameKillEnabled", false);
 		OVO_REWARD_FAME_KILLER = settings.getInt("EventRewardFameKill", 10);
 		OVO_COUNT_TEAM = settings.getInt("EventCountTeam", 2);
-		OVO_COORDINATES_TEAM = settings.getLocationList("EventTeamCoordinates");
-		checkTeamAndSpawn("OneVsOne", OVO_COORDINATES_TEAM, OVO_COUNT_TEAM);
+		OVO_COORDINATES_TEAM = settings.getMultipleLocationList("EventTeamCoordinates");
+		checkTeamAndMultipleSpawn("OneVsOne", OVO_COORDINATES_TEAM, OVO_COUNT_TEAM);
 		
 		// ------------------------------------------------------------------------------------- //
 		// TeamVsTeam.properties
@@ -232,8 +232,8 @@ public class ConfigData
 		TVT_REWARD_FAME_KILLER = settings.getInt("EventRewardFameKill", 10);
 		
 		TVT_COUNT_TEAM = settings.getInt("EventCountTeam", 2);
-		TVT_COORDINATES_TEAM = settings.getLocationList("EventTeamCoordinates");
-		checkTeamAndSpawn("TeamVsTeam", TVT_COORDINATES_TEAM, TVT_COUNT_TEAM);
+		TVT_COORDINATES_TEAM = settings.getMultipleLocationList("EventTeamCoordinates");
+		checkTeamAndMultipleSpawn("TeamVsTeam", TVT_COORDINATES_TEAM, TVT_COUNT_TEAM);
 		
 		// ------------------------------------------------------------------------------------- //
 		// Survive.properties
@@ -246,20 +246,19 @@ public class ConfigData
 		SURVIVE_MONSTERS_ID = settings.getListInteger("EventMobsID");
 		SURVIVE_MONSTER_SPAWN_FOR_STAGE = settings.getInt("EventMobsSpawnForStage", 5);
 		SURVIVE_COUNT_TEAM = settings.getInt("EventCountTeam", 2);
-		SURVIVE_COORDINATES_TEAM = settings.getLocationList("EventTeamCoordinates");
+		SURVIVE_COORDINATES_TEAM = settings.getMultipleLocationList("EventTeamCoordinates");
 	}
 	
 	/**
-	 * Chequemos la cantidad de teams indicados en cada evento y que cada uno tenga un spawn definido.
+	 * Chequemos la cantidad de teams indicados en cada evento y que cada uno tenga un grupo de spawns definidos.
 	 */
-	private void checkTeamAndSpawn(String eventName, List<Location> locs, int teams)
+	private void checkTeamAndMultipleSpawn(String eventName, ArrayList<Locations> locs, int teams)
 	{
 		if (locs.size() != teams)
 		{
-			LOGGER.warning(ConfigData.class.getSimpleName() + ": " + eventName + "-> La cantidad de teams no coincide con la cantidad de spawns");
+			LOGGER.warning(ConfigData.class.getSimpleName() + ": " + eventName + "-> The amount of teams is not equals to amount of locations");
 			LOGGER.info("locs.size() " + locs.size());
 			LOGGER.info("teams " + teams);
-			
 		}
 	}
 	

--- a/java/net/sf/eventengine/events/AllVsAll.java
+++ b/java/net/sf/eventengine/events/AllVsAll.java
@@ -20,13 +20,6 @@ package net.sf.eventengine.events;
 
 import java.util.List;
 
-import com.l2jserver.gameserver.model.actor.L2Character;
-import com.l2jserver.gameserver.model.actor.L2Npc;
-import com.l2jserver.gameserver.model.instancezone.InstanceWorld;
-import com.l2jserver.gameserver.model.items.L2Item;
-import com.l2jserver.gameserver.model.skills.Skill;
-import com.l2jserver.gameserver.network.clientpackets.Say2;
-
 import net.sf.eventengine.datatables.ConfigData;
 import net.sf.eventengine.datatables.MessageData;
 import net.sf.eventengine.enums.CollectionTarget;
@@ -38,13 +31,20 @@ import net.sf.eventengine.events.schedules.AnnounceNearEndEvent;
 import net.sf.eventengine.util.EventUtil;
 import net.sf.eventengine.util.SortUtil;
 
+import com.l2jserver.gameserver.model.actor.L2Character;
+import com.l2jserver.gameserver.model.actor.L2Npc;
+import com.l2jserver.gameserver.model.instancezone.InstanceWorld;
+import com.l2jserver.gameserver.model.items.L2Item;
+import com.l2jserver.gameserver.model.skills.Skill;
+import com.l2jserver.gameserver.network.clientpackets.Say2;
+
 /**
  * @author fissban
  */
 public class AllVsAll extends AbstractEvent
 {
 	// Radius spawn
-	private static final int RADIUS_SPAWN_PLAYER = 100;
+	private static final int RADIUS_SPAWN_PLAYER = 10;
 	// Time for resurrection
 	private static final int TIME_RES_PLAYER = 10;
 	
@@ -68,11 +68,11 @@ public class AllVsAll extends AbstractEvent
 				createTeam(1);
 				teleportAllPlayers(RADIUS_SPAWN_PLAYER);
 				break;
-				
+			
 			case FIGHT:
 				prepareToFight(); // General Method
 				break;
-				
+			
 			case END:
 				giveRewardsTeams();
 				prepareToEnd(); // General Method

--- a/java/net/sf/eventengine/events/CaptureTheFlag.java
+++ b/java/net/sf/eventengine/events/CaptureTheFlag.java
@@ -37,6 +37,7 @@ import net.sf.eventengine.util.SortUtil;
 
 import com.l2jserver.gameserver.datatables.ItemTable;
 import com.l2jserver.gameserver.enums.Team;
+import com.l2jserver.gameserver.model.Location;
 import com.l2jserver.gameserver.model.actor.L2Character;
 import com.l2jserver.gameserver.model.actor.L2Npc;
 import com.l2jserver.gameserver.model.instancezone.InstanceWorld;
@@ -63,7 +64,7 @@ public class CaptureTheFlag extends AbstractEvent
 	private final int POINTS_CONQUER_FLAG = ConfigData.getInstance().CTF_POINTS_CONQUER_FLAG;
 	private final int POINTS_KILL = ConfigData.getInstance().CTF_POINTS_KILL;
 	// Radius spawn
-	private static final int RADIUS_SPAWN_PLAYER = 100;
+	private static final int RADIUS_SPAWN_PLAYER = 10;
 	// Time for resurrection
 	private static final int TIME_RES_PLAYER = 10;
 	
@@ -148,7 +149,8 @@ public class CaptureTheFlag extends AbstractEvent
 					
 					TeamHolder th = getTeam(_flagHasPlayer.remove(ph));
 					// We created the flag again
-					_flagSpawn.put(addEventNpc(FLAG, th.getSpawn().getX(), th.getSpawn().getY(), th.getSpawn().getZ(), 0, Team.NONE, th.getTeamType().name(), false, getInstancesWorlds().get(0).getInstanceId()), th.getTeamType());
+					Location loc = th.getSpawns().getRandomSpawn();
+					_flagSpawn.put(addEventNpc(FLAG, loc.getX(), loc.getY(), loc.getZ(), 0, Team.NONE, th.getTeamType().name(), false, getInstancesWorlds().get(0).getInstanceId()), th.getTeamType());
 					// We announced that a flag was taken
 					EventUtil.announceTo(Say2.BATTLEFIELD, "ctf_conquered_the_flag", "%holder%", th.getTeamType().name(), CollectionTarget.ALL_PLAYERS_IN_EVENT);
 					// Show points of each team
@@ -262,9 +264,11 @@ public class CaptureTheFlag extends AbstractEvent
 		
 		for (TeamHolder th : getAllTeams())
 		{
-			int x = th.getSpawn().getX();
-			int y = th.getSpawn().getY();
-			int z = th.getSpawn().getZ();
+			Location loc = th.getSpawns().getRandomSpawn();
+			
+			int x = loc.getX();
+			int y = loc.getY();
+			int z = loc.getZ();
 			TeamType tt = th.getTeamType();
 			
 			_flagSpawn.put(addEventNpc(FLAG, x, y, z, 0, Team.NONE, th.getTeamType().name(), false, instanceId), tt);

--- a/java/net/sf/eventengine/events/Survive.java
+++ b/java/net/sf/eventengine/events/Survive.java
@@ -20,16 +20,6 @@ package net.sf.eventengine.events;
 
 import java.util.List;
 
-import com.l2jserver.gameserver.ThreadPoolManager;
-import com.l2jserver.gameserver.enums.Team;
-import com.l2jserver.gameserver.model.actor.L2Character;
-import com.l2jserver.gameserver.model.actor.L2Npc;
-import com.l2jserver.gameserver.model.instancezone.InstanceWorld;
-import com.l2jserver.gameserver.model.items.L2Item;
-import com.l2jserver.gameserver.model.skills.Skill;
-import com.l2jserver.gameserver.network.clientpackets.Say2;
-import com.l2jserver.util.Rnd;
-
 import net.sf.eventengine.datatables.ConfigData;
 import net.sf.eventengine.enums.CollectionTarget;
 import net.sf.eventengine.enums.EventState;
@@ -40,6 +30,16 @@ import net.sf.eventengine.events.holders.TeamHolder;
 import net.sf.eventengine.events.schedules.AnnounceNearEndEvent;
 import net.sf.eventengine.util.EventUtil;
 import net.sf.eventengine.util.SortUtil;
+
+import com.l2jserver.gameserver.ThreadPoolManager;
+import com.l2jserver.gameserver.enums.Team;
+import com.l2jserver.gameserver.model.actor.L2Character;
+import com.l2jserver.gameserver.model.actor.L2Npc;
+import com.l2jserver.gameserver.model.instancezone.InstanceWorld;
+import com.l2jserver.gameserver.model.items.L2Item;
+import com.l2jserver.gameserver.model.skills.Skill;
+import com.l2jserver.gameserver.network.clientpackets.Say2;
+import com.l2jserver.util.Rnd;
 
 /**
  * Event survival<br>
@@ -53,7 +53,7 @@ public class Survive extends AbstractEvent
 	// Variable that helps us keep track of the number of dead mobs.
 	private int _auxKillMonsters = 0;
 	// Radius spawn
-	private static final int RADIUS_SPAWN_PLAYER = 200;
+	private static final int RADIUS_SPAWN_PLAYER = 10;
 	
 	// Monsters ids
 	private final List<Integer> MONSTERS_ID = ConfigData.getInstance().SURVIVE_MONSTERS_ID;
@@ -78,12 +78,12 @@ public class Survive extends AbstractEvent
 				createTeam(ConfigData.getInstance().SURVIVE_COUNT_TEAM);
 				teleportAllPlayers(RADIUS_SPAWN_PLAYER);
 				break;
-				
+			
 			case FIGHT:
 				prepareToFight(); // General Method
 				spawnsMobs();
 				break;
-				
+			
 			case END:
 				// showResult();
 				giveRewardsTeams();
@@ -211,7 +211,7 @@ public class Survive extends AbstractEvent
 				// FIXME agregar al sistema de lang
 				EventUtil.sendEventScreenMessage(ph, "Stage " + _stage, 5000);
 			}
-		} , 5000L);
+		}, 5000L);
 		
 	}
 	

--- a/java/net/sf/eventengine/events/TeamVsTeam.java
+++ b/java/net/sf/eventengine/events/TeamVsTeam.java
@@ -20,13 +20,6 @@ package net.sf.eventengine.events;
 
 import java.util.List;
 
-import com.l2jserver.gameserver.model.actor.L2Character;
-import com.l2jserver.gameserver.model.actor.L2Npc;
-import com.l2jserver.gameserver.model.instancezone.InstanceWorld;
-import com.l2jserver.gameserver.model.items.L2Item;
-import com.l2jserver.gameserver.model.skills.Skill;
-import com.l2jserver.gameserver.network.clientpackets.Say2;
-
 import net.sf.eventengine.datatables.ConfigData;
 import net.sf.eventengine.datatables.MessageData;
 import net.sf.eventengine.enums.CollectionTarget;
@@ -39,13 +32,20 @@ import net.sf.eventengine.events.schedules.AnnounceNearEndEvent;
 import net.sf.eventengine.util.EventUtil;
 import net.sf.eventengine.util.SortUtil;
 
+import com.l2jserver.gameserver.model.actor.L2Character;
+import com.l2jserver.gameserver.model.actor.L2Npc;
+import com.l2jserver.gameserver.model.instancezone.InstanceWorld;
+import com.l2jserver.gameserver.model.items.L2Item;
+import com.l2jserver.gameserver.model.skills.Skill;
+import com.l2jserver.gameserver.network.clientpackets.Say2;
+
 /**
  * @author fissban
  */
 public class TeamVsTeam extends AbstractEvent
 {
 	// Radius spawn
-	private static final int RADIUS_SPAWN_PLAYER = 100;
+	private static final int RADIUS_SPAWN_PLAYER = 10;
 	// Time for resurrection
 	private static final int TIME_RES_PLAYER = 10;
 	
@@ -69,12 +69,12 @@ public class TeamVsTeam extends AbstractEvent
 				createTeams(ConfigData.getInstance().TVT_COUNT_TEAM);
 				teleportAllPlayers(RADIUS_SPAWN_PLAYER);
 				break;
-				
+			
 			case FIGHT:
 				prepareToFight(); // General Method
 				showPoint();
 				break;
-				
+			
 			case END:
 				// showResult();
 				giveRewardsTeams();

--- a/java/net/sf/eventengine/events/handler/AbstractEvent.java
+++ b/java/net/sf/eventengine/events/handler/AbstractEvent.java
@@ -28,6 +28,23 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledFuture;
 import java.util.logging.Logger;
 
+import net.sf.eventengine.EventEngineManager;
+import net.sf.eventengine.EventEngineWorld;
+import net.sf.eventengine.datatables.BuffListData;
+import net.sf.eventengine.datatables.ConfigData;
+import net.sf.eventengine.datatables.MessageData;
+import net.sf.eventengine.enums.EventState;
+import net.sf.eventengine.enums.TeamType;
+import net.sf.eventengine.events.holders.PlayerHolder;
+import net.sf.eventengine.events.holders.TeamHolder;
+import net.sf.eventengine.events.schedules.AnnounceTeleportEvent;
+import net.sf.eventengine.events.schedules.ChangeToEndEvent;
+import net.sf.eventengine.events.schedules.ChangeToFightEvent;
+import net.sf.eventengine.events.schedules.ChangeToStartEvent;
+import net.sf.eventengine.events.schedules.interfaces.EventScheduled;
+import net.sf.eventengine.model.Locations;
+import net.sf.eventengine.util.EventUtil;
+
 import com.l2jserver.gameserver.ThreadPoolManager;
 import com.l2jserver.gameserver.data.xml.impl.NpcData;
 import com.l2jserver.gameserver.datatables.SpawnTable;
@@ -51,22 +68,6 @@ import com.l2jserver.gameserver.model.skills.Skill;
 import com.l2jserver.gameserver.network.serverpackets.MagicSkillUse;
 import com.l2jserver.gameserver.taskmanager.DecayTaskManager;
 import com.l2jserver.util.Rnd;
-
-import net.sf.eventengine.EventEngineManager;
-import net.sf.eventengine.EventEngineWorld;
-import net.sf.eventengine.datatables.BuffListData;
-import net.sf.eventengine.datatables.ConfigData;
-import net.sf.eventengine.datatables.MessageData;
-import net.sf.eventengine.enums.EventState;
-import net.sf.eventengine.enums.TeamType;
-import net.sf.eventengine.events.holders.PlayerHolder;
-import net.sf.eventengine.events.holders.TeamHolder;
-import net.sf.eventengine.events.schedules.AnnounceTeleportEvent;
-import net.sf.eventengine.events.schedules.ChangeToEndEvent;
-import net.sf.eventengine.events.schedules.ChangeToFightEvent;
-import net.sf.eventengine.events.schedules.ChangeToStartEvent;
-import net.sf.eventengine.events.schedules.interfaces.EventScheduled;
-import net.sf.eventengine.util.EventUtil;
 
 /**
  * @author fissban
@@ -147,7 +148,8 @@ public abstract class AbstractEvent
 	 * @param team
 	 * @param locs
 	 */
-	public void setSpawnTeams(List<Location> locs)
+	
+	public void setSpawnTeams(ArrayList<Locations> locs)
 	{
 		if (locs.size() < _countTeams)
 		{
@@ -156,32 +158,31 @@ public abstract class AbstractEvent
 			LOGGER.warning(AbstractEvent.class.getSimpleName() + ": Cantidad de locs: " + locs.size());
 			return;
 		}
-		
 		for (int i = 0; i < _countTeams; i++)
 		{
-			setSpawn(TeamType.values()[i + 1], locs.get(i));
+			setSpawns(TeamType.values()[i + 1], locs.get(i));
 		}
 	}
 	
 	/**
-	 * We define a team spawns.
+	 * Set the team spawns.
 	 * @param team
 	 * @param loc
 	 */
-	public void setSpawn(TeamType team, Location loc)
+	
+	public void setSpawns(TeamType team, Locations loc)
 	{
-		_teams.get(team).setSpawn(loc);
+		_teams.get(team).setSpawns(loc);
 	}
 	
 	/**
-	 * We get the spawn of a particular team.
+	 * Get the spawns of a particular team.
 	 * @param team
 	 * @return Location
 	 */
-	public Location getTeamSpawn(TeamType team)
-	{
-		return _teams.get(team).getSpawn();
-	}
+	/*
+	 * public Location getTeamSpawn(TeamType team) { return _teams.get(team).getSpawns(); }
+	 */
 	
 	// XXX DINAMIC INSTANCE ------------------------------------------------------------------------------
 	private String _instanceFile = "";
@@ -760,8 +761,7 @@ public abstract class AbstractEvent
 	 */
 	protected void teleportPlayer(PlayerHolder ph, int radius)
 	{
-		// get the spawn defined at the start of each event
-		Location loc = getTeamSpawn(ph.getTeamType());
+		Location loc = getTeam(ph.getTeamType()).getSpawns().getRandomSpawn();
 		
 		loc.setInstanceId(ph.getDinamicInstanceId());
 		loc.setX(loc.getX() + Rnd.get(-radius, radius));
@@ -900,7 +900,7 @@ public abstract class AbstractEvent
 				giveBuffPlayer(player.getPcInstance());
 				teleportPlayer(player, radiusTeleport);
 				
-			} , time * 1000));
+			}, time * 1000));
 		}
 		catch (Exception e)
 		{
@@ -993,6 +993,6 @@ public abstract class AbstractEvent
 		{
 			_currentTime += 1000;
 			checkScheduledEvents();
-		} , 10 * 1000, 1000);
+		}, 10 * 1000, 1000);
 	}
 }

--- a/java/net/sf/eventengine/events/holders/TeamHolder.java
+++ b/java/net/sf/eventengine/events/holders/TeamHolder.java
@@ -21,20 +21,19 @@ package net.sf.eventengine.events.holders;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import net.sf.eventengine.enums.TeamType;
-
-import com.l2jserver.gameserver.model.Location;
+import net.sf.eventengine.model.Locations;
 
 /**
  * @author fissban
  */
 public class TeamHolder
 {
-	// Tipo de team
+	// Team type
 	private TeamType _teamType;
-	// Cantidad de puntos
+	// Amount of points
 	private AtomicInteger _points = new AtomicInteger(0);
-	// Spawn del team
-	private Location _teamSpawn = new Location(0, 0, 0);
+	// List of team spawns
+	private Locations _teamSpawns;
 	
 	/**
 	 * Constructor
@@ -46,7 +45,7 @@ public class TeamHolder
 	}
 	
 	/**
-	 * Obtenemos el color del team
+	 * Get the team color
 	 * @return
 	 */
 	public TeamType getTeamType()
@@ -55,25 +54,25 @@ public class TeamHolder
 	}
 	
 	/**
-	 * Definimos el spawn de un team.
+	 * Set the team spawns
 	 * @param loc
 	 */
-	public void setSpawn(Location loc)
+	public void setSpawns(Locations locs)
 	{
-		_teamSpawn = loc;
+		_teamSpawns = locs;
 	}
 	
 	/**
-	 * Obtenemos el spawn de un team.
+	 * Get the team spawns
 	 * @return
 	 */
-	public Location getSpawn()
+	public Locations getSpawns()
 	{
-		return _teamSpawn;
+		return _teamSpawns;
 	}
 	
 	/**
-	 * Puntos del team
+	 * Get team points
 	 * @return
 	 */
 	public int getPoints()
@@ -82,7 +81,7 @@ public class TeamHolder
 	}
 	
 	/**
-	 * Incrementamos la cantidad de puntos
+	 * Increase the points
 	 */
 	public void increasePoints(int points)
 	{
@@ -90,7 +89,7 @@ public class TeamHolder
 	}
 	
 	/**
-	 * Disminiumos la cantidad de puntos
+	 * Reduce the points
 	 */
 	public void decreasePoints(int points)
 	{

--- a/java/net/sf/eventengine/model/Locations.java
+++ b/java/net/sf/eventengine/model/Locations.java
@@ -1,0 +1,55 @@
+package net.sf.eventengine.model;
+
+import java.util.ArrayList;
+
+import com.l2jserver.gameserver.model.Location;
+import com.l2jserver.util.Rnd;
+
+public class Locations
+{
+	private ArrayList<Location> _locs;
+	
+	/**
+	 * Constructor
+	 */
+	public Locations()
+	{
+		_locs = new ArrayList<>();
+	}
+	
+	/**
+	 * Constructor
+	 * @param locs
+	 */
+	public Locations(ArrayList<Location> locs)
+	{
+		_locs = locs;
+	}
+	
+	/**
+	 * Add a location
+	 * @return
+	 */
+	public void addLoc(Location loc)
+	{
+		_locs.add(loc);
+	}
+	
+	/**
+	 * Get the locations
+	 * @return
+	 */
+	public ArrayList<Location> getLocs()
+	{
+		return _locs;
+	}
+	
+	/**
+	 * Get a random location
+	 * @return
+	 */
+	public Location getRandomSpawn()
+	{
+		return _locs.get(Rnd.get(_locs.size() - 1));
+	}
+}

--- a/java/net/sf/eventengine/util/EventPropertiesParser.java
+++ b/java/net/sf/eventengine/util/EventPropertiesParser.java
@@ -23,11 +23,12 @@ import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.StringTokenizer;
 import java.util.logging.Logger;
+
+import net.sf.eventengine.model.Locations;
 
 import com.l2jserver.gameserver.model.Location;
 import com.l2jserver.gameserver.model.holders.ItemHolder;
@@ -298,22 +299,20 @@ public final class EventPropertiesParser
 	}
 	
 	/**
-	 * Parseamos un config usando "," para diferenciar entre cada coordenada y un ";" entre cada team. <br>
-	 * Ejemplo -> "xx,xx,xx"
+	 * Transform a string with the following format 'XX,XX,XX;XX,XX,XX#XX,XX,XX' to list of Locations.<br>
 	 * @param key
 	 * @return List<Location>
 	 */
-	public List<Location> getLocationList(String key)
+	public ArrayList<Locations> getMultipleLocationList(String key)
 	{
 		try
 		{
-			List<Location> locList = new ArrayList<>();
+			ArrayList<Locations> locList = new ArrayList<>();
 			
-			StringTokenizer st = new StringTokenizer(getValue(key), ";");
+			StringTokenizer st = new StringTokenizer(getValue(key), "#");
 			while (st.hasMoreTokens())
 			{
-				StringTokenizer stLoc = new StringTokenizer(st.nextToken(), ",");
-				locList.add(new Location(Integer.parseInt(stLoc.nextToken()), Integer.parseInt(stLoc.nextToken()), Integer.parseInt(stLoc.nextToken())));
+				locList.add(getLocationList(st.nextToken().toString()));
 			}
 			
 			return locList;
@@ -323,7 +322,35 @@ public final class EventPropertiesParser
 			LOGGER.warning(getClass().getSimpleName() + ": fail to read config -> " + key);
 		}
 		
-		return Collections.emptyList();
+		return new ArrayList<>();
+	}
+	
+	/**
+	 * Transform a string with the following format 'XX,XX,XX;XX,XX,XX' to Locations object.<br>
+	 * @param key
+	 * @return Locations
+	 */
+	public Locations getLocationList(String key)
+	{
+		Locations locList = new Locations();
+		
+		try
+		{
+			StringTokenizer st = new StringTokenizer(key, ";");
+			while (st.hasMoreTokens())
+			{
+				StringTokenizer stLoc = new StringTokenizer(st.nextToken(), ",");
+				locList.addLoc(new Location(Integer.parseInt(stLoc.nextToken()), Integer.parseInt(stLoc.nextToken()), Integer.parseInt(stLoc.nextToken())));
+			}
+			
+			return locList;
+		}
+		catch (Exception e)
+		{
+			LOGGER.warning(getClass().getSimpleName() + ": fail to read config -> " + key);
+		}
+		
+		return locList;
 	}
 	
 	/**


### PR DESCRIPTION
## Summary

Ahora los spawns de los equipos son tratados como un objecto Locations que contiene una lista de localizaciones, abstrayéndonos de la cantidad de spawns que puede tener un equipo (pueden usarse uno o muchos). Debido a este cambio, se disminuyó el radio de spawn para evitar que los jugadores queden atrapados en la pared.

La decisión por la cual hay un modelo 'Locations' es para evitar tener líneas cómo ArrayList< List< Location > >. Además, se le pueden preguntar cosas al modelo (por ahora, que nos dé una loc random de su lista).
## Nota

Actualmente las flags en CTF utilizan los spawns de los equipos. Lo ideal sería que tengan su propia loc. Será un tema a tratar en otro PR.
