### PR TITLE
Feature/max box per ip

### DIFF
--- a/dist/game/config/EventEngine/EventEngine.properties
+++ b/dist/game/config/EventEngine/EventEngine.properties
@@ -66,3 +66,7 @@ EventMaxPlayerLevel = 85
 # Maximum number of buffs you can choose
 # Default 5
 EventMaxBuffCount = 5
+
+# Maximum number of participants per pc
+# 0 -> unlimited
+EventMaxParticipantPerPc = 0

--- a/dist/game/config/EventEngine/Language/lang_en.xml
+++ b/dist/game/config/EventEngine/Language/lang_en.xml
@@ -40,6 +40,7 @@
 	<message id="unregistering_unregistered" text="You have been unregistered." />
 	<message id="unregistering_notRegistered" text="You are not registered!" />
 	<message id="registering_maxPlayers" text="Sorry, since the maximum amount of players registered." />
+	<message id="registering_maxPlayersPerPc" text="Sorry, the maximum number of participants is exceeded by Pc" />
 	
 	<!-- Events Info -->
 	<message id="event_allvsall_name" text="All vs All" />

--- a/java/net/sf/eventengine/ai/NpcManager.java
+++ b/java/net/sf/eventengine/ai/NpcManager.java
@@ -77,6 +77,11 @@ public class NpcManager extends Quest
 				break;
 			
 			case "vote":
+				if (!EventEngineManager.getInstance().isOpenVote())
+				{
+					// bypaseando o simplemente tuvo mucho tiempo abierta la ventana?
+					break;
+				}
 				// Add vote event
 				Class<? extends AbstractEvent> type = EventData.getInstance().getEvent(st.nextToken());
 				if (type != null)
@@ -93,29 +98,34 @@ public class NpcManager extends Quest
 				break;
 			
 			case "register":
-				if (EventEngineManager.getInstance().registerPlayer(player))
+				if (!EventEngineManager.getInstance().isOpenRegister())
 				{
-					// Check for register
-					if (player.getLevel() < ConfigData.getInstance().MIN_LVL_IN_EVENT)
-					{
-						player.sendMessage(MessageData.getInstance().getMsgByLang(player, "registering_lowLevel", true));
-					}
-					else if (player.getLevel() > ConfigData.getInstance().MAX_LVL_IN_EVENT)
-					{
-						player.sendMessage(MessageData.getInstance().getMsgByLang(player, "registering_highLevel", true));
-					}
-					else if (EventEngineManager.getInstance().getAllRegisteredPlayers().size() >= ConfigData.getInstance().MAX_PLAYERS_IN_EVENT)
-					{
-						player.sendMessage(MessageData.getInstance().getMsgByLang(player, "registering_maxPlayers", true));
-					}
-					else
-					{
-						player.sendMessage(MessageData.getInstance().getMsgByLang(player, "registering_registered", true));
-					}
+					// bypaseando o simplemente tuvo mucho tiempo abierta la ventana?
+					break;
+				}
+				else if (EventEngineManager.getInstance().isRegistered(player))
+				{
+					player.sendMessage(MessageData.getInstance().getMsgByLang(player, "registering_registered", true));
+				}
+				else if (player.getLevel() < ConfigData.getInstance().MIN_LVL_IN_EVENT)
+				{
+					player.sendMessage(MessageData.getInstance().getMsgByLang(player, "registering_lowLevel", true));
+				}
+				else if (player.getLevel() > ConfigData.getInstance().MAX_LVL_IN_EVENT)
+				{
+					player.sendMessage(MessageData.getInstance().getMsgByLang(player, "registering_highLevel", true));
+				}
+				else if (EventEngineManager.getInstance().getAllRegisteredPlayers().size() >= ConfigData.getInstance().MAX_PLAYERS_IN_EVENT)
+				{
+					player.sendMessage(MessageData.getInstance().getMsgByLang(player, "registering_maxPlayers", true));
+				}
+				else if (EventEngineManager.getInstance().checkMultiBox(player))
+				{
+					player.sendMessage(MessageData.getInstance().getMsgByLang(player, "registering_maxPlayersPerPc", true));
 				}
 				else
 				{
-					player.sendMessage(MessageData.getInstance().getMsgByLang(player, "registering_already_registered", true));
+					EventEngineManager.getInstance().registerPlayer(player);
 				}
 				
 				sendHtmlIndex(player);
@@ -155,6 +165,11 @@ public class NpcManager extends Quest
 				break;
 			
 			case "buffs":
+				// prevenimos de que mantengan la ventana abierta durante el evento y cambien sus buffs
+				if (EventEngineManager.getInstance().getCurrentEvent() != null)
+				{
+					break;
+				}
 				int page = 1;
 				
 				if (st.hasMoreTokens())

--- a/java/net/sf/eventengine/datatables/ConfigData.java
+++ b/java/net/sf/eventengine/datatables/ConfigData.java
@@ -55,6 +55,7 @@ public class ConfigData
 	public int MIN_LVL_IN_EVENT;
 	public int MAX_LVL_IN_EVENT;
 	public static int MAX_BUFF_COUNT;
+	public static int MAX_PARTICIPANT_PER_PC;
 	
 	// -------------------------------------------------------------------------------
 	// Configs Capture The Flag
@@ -159,6 +160,7 @@ public class ConfigData
 		MIN_LVL_IN_EVENT = settings.getInt("EventMinPlayerLevel", 40);
 		MAX_LVL_IN_EVENT = settings.getInt("EventMaxPlayerLevel", 78);
 		MAX_BUFF_COUNT = settings.getInt("EventMaxBuffCount", 5);
+		MAX_PARTICIPANT_PER_PC = settings.getInt("EventMaxParticipantPerPc", 0);
 		
 		// ------------------------------------------------------------------------------------- //
 		// CaptureTheFlag.properties


### PR DESCRIPTION
- Agregamos sistema de ip/trace para limitar los participantes que
  pueden participar por Pc.
- Se agrega al  xml de lang el mensaje para cuando se supera el maximo
  de participantes por Pc.
- Se repara error por el cual los personajes se podian registrar aun
  cuando no cumplian los requisitos.
- Se agregan restricciones para el uso de los bypass del NpcManager.
## *\* Sistema sin ningun tipo de test **

@luksdlt92 revisa este trabajo....esta echo a partir de mi rama "addMoreEvents" inecesariamente.
@u3games testea este codigo desde mas de 1 pc por favor.
