### PR TITLE
Code cleanup

### DIFF
--- a/java/net/sf/eventengine/events/AllVsAll.java
+++ b/java/net/sf/eventengine/events/AllVsAll.java
@@ -20,23 +20,19 @@ package net.sf.eventengine.events;
 
 import java.util.List;
 
-import com.l2jserver.gameserver.model.actor.L2Character;
-import com.l2jserver.gameserver.model.actor.L2Npc;
-import com.l2jserver.gameserver.model.instancezone.InstanceWorld;
-import com.l2jserver.gameserver.model.items.L2Item;
-import com.l2jserver.gameserver.model.skills.Skill;
-import com.l2jserver.gameserver.network.clientpackets.Say2;
-
 import net.sf.eventengine.datatables.ConfigData;
 import net.sf.eventengine.datatables.MessageData;
 import net.sf.eventengine.enums.CollectionTarget;
-import net.sf.eventengine.enums.EventState;
 import net.sf.eventengine.enums.TeamType;
 import net.sf.eventengine.events.handler.AbstractEvent;
 import net.sf.eventengine.events.holders.PlayerHolder;
 import net.sf.eventengine.events.schedules.AnnounceNearEndEvent;
 import net.sf.eventengine.util.EventUtil;
 import net.sf.eventengine.util.SortUtil;
+
+import com.l2jserver.gameserver.model.actor.L2Character;
+import com.l2jserver.gameserver.model.instancezone.InstanceWorld;
+import com.l2jserver.gameserver.network.clientpackets.Say2;
 
 /**
  * @author fissban
@@ -59,26 +55,22 @@ public class AllVsAll extends AbstractEvent
 	}
 	
 	@Override
-	public void runEventState(EventState state)
+	protected void onEventStart()
 	{
-		switch (state)
-		{
-			case START:
-				prepareToStart(); // General Method
-				createTeam(1);
-				teleportAllPlayers(RADIUS_SPAWN_PLAYER);
-				break;
-				
-			case FIGHT:
-				prepareToFight(); // General Method
-				break;
-				
-			case END:
-				giveRewardsTeams();
-				prepareToEnd(); // General Method
-				break;
-		}
-		
+		createTeam(1);
+		teleportAllPlayers(RADIUS_SPAWN_PLAYER);
+	}
+	
+	@Override
+	protected void onEventFight()
+	{
+		// Nothing
+	}
+	
+	@Override
+	protected void onEventEnd()
+	{
+		giveRewardsTeams();
 	}
 	
 	// LISTENERS -----------------------------------------------------------------------
@@ -117,18 +109,6 @@ public class AllVsAll extends AbstractEvent
 	}
 	
 	@Override
-	public boolean onAttack(PlayerHolder ph, L2Character target)
-	{
-		return false;
-	}
-	
-	@Override
-	public boolean onUseSkill(PlayerHolder ph, L2Character target, Skill skill)
-	{
-		return false;
-	}
-	
-	@Override
 	public void onDeath(PlayerHolder ph)
 	{
 		// We generated a task to revive the player
@@ -137,24 +117,6 @@ public class AllVsAll extends AbstractEvent
 		ph.increaseDeaths();
 		// We update the title character
 		updateTitle(ph);
-	}
-	
-	@Override
-	public boolean onInteract(PlayerHolder ph, L2Npc npc)
-	{
-		return true;
-	}
-	
-	@Override
-	public boolean onUseItem(PlayerHolder ph, L2Item item)
-	{
-		return false;
-	}
-	
-	@Override
-	public void onLogout(PlayerHolder ph)
-	{
-		//
 	}
 	
 	// VARIOUS METHODS ------------------------------------------------------------------

--- a/java/net/sf/eventengine/events/CaptureTheFlag.java
+++ b/java/net/sf/eventengine/events/CaptureTheFlag.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import net.sf.eventengine.datatables.ConfigData;
 import net.sf.eventengine.datatables.MessageData;
 import net.sf.eventengine.enums.CollectionTarget;
-import net.sf.eventengine.enums.EventState;
 import net.sf.eventengine.enums.TeamType;
 import net.sf.eventengine.events.handler.AbstractEvent;
 import net.sf.eventengine.events.holders.PlayerHolder;
@@ -44,7 +43,6 @@ import com.l2jserver.gameserver.model.itemcontainer.Inventory;
 import com.l2jserver.gameserver.model.items.L2Item;
 import com.l2jserver.gameserver.model.items.L2Weapon;
 import com.l2jserver.gameserver.model.items.instance.L2ItemInstance;
-import com.l2jserver.gameserver.model.skills.Skill;
 import com.l2jserver.gameserver.network.clientpackets.Say2;
 import com.l2jserver.gameserver.network.serverpackets.MagicSkillUse;
 
@@ -82,27 +80,24 @@ public class CaptureTheFlag extends AbstractEvent
 	}
 	
 	@Override
-	public void runEventState(EventState state)
+	protected void onEventStart()
 	{
-		switch (state)
-		{
-			case START:
-				prepareToStart(); // General Method
-				createTeams(ConfigData.getInstance().CTF_COUNT_TEAM);
-				spawnFlagsAndHolders();
-				teleportAllPlayers(RADIUS_SPAWN_PLAYER);
-				break;
-			
-			case FIGHT:
-				prepareToFight(); // General Method
-				break;
-			
-			case END:
-				clearFlags();
-				giveRewardsTeams();
-				prepareToEnd(); // General Method
-				break;
-		}
+		createTeams(ConfigData.getInstance().CTF_COUNT_TEAM);
+		spawnFlagsAndHolders();
+		teleportAllPlayers(RADIUS_SPAWN_PLAYER);
+	}
+	
+	@Override
+	protected void onEventFight()
+	{
+		// Nothing
+	}
+	
+	@Override
+	protected void onEventEnd()
+	{
+		clearFlags();
+		giveRewardsTeams();
 	}
 	
 	@Override
@@ -209,18 +204,6 @@ public class CaptureTheFlag extends AbstractEvent
 	public void onDeath(PlayerHolder ph)
 	{
 		giveResurrectPlayer(ph, TIME_RES_PLAYER, RADIUS_SPAWN_PLAYER);
-	}
-	
-	@Override
-	public boolean onAttack(PlayerHolder ph, L2Character target)
-	{
-		return false;
-	}
-	
-	@Override
-	public boolean onUseSkill(PlayerHolder ph, L2Character target, Skill skill)
-	{
-		return false;
 	}
 	
 	@Override

--- a/java/net/sf/eventengine/events/OneVsOne.java
+++ b/java/net/sf/eventengine/events/OneVsOne.java
@@ -24,24 +24,20 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import com.l2jserver.gameserver.ThreadPoolManager;
-import com.l2jserver.gameserver.model.actor.L2Character;
-import com.l2jserver.gameserver.model.actor.L2Npc;
-import com.l2jserver.gameserver.model.instancezone.InstanceWorld;
-import com.l2jserver.gameserver.model.items.L2Item;
-import com.l2jserver.gameserver.model.skills.Skill;
-
 import net.sf.eventengine.EventEngineManager;
 import net.sf.eventengine.datatables.ConfigData;
 import net.sf.eventengine.datatables.MessageData;
 import net.sf.eventengine.enums.EventEngineState;
-import net.sf.eventengine.enums.EventState;
 import net.sf.eventengine.enums.TeamType;
 import net.sf.eventengine.events.handler.AbstractEvent;
 import net.sf.eventengine.events.holders.PlayerHolder;
 import net.sf.eventengine.events.schedules.AnnounceNearEndEvent;
 import net.sf.eventengine.util.EventUtil;
 import net.sf.eventengine.util.SortUtil;
+
+import com.l2jserver.gameserver.ThreadPoolManager;
+import com.l2jserver.gameserver.model.actor.L2Character;
+import com.l2jserver.gameserver.model.instancezone.InstanceWorld;
 
 /**
  * @author fissban
@@ -65,40 +61,25 @@ public class OneVsOne extends AbstractEvent
 	}
 	
 	@Override
-	public void runEventState(EventState state)
+	protected void onEventStart()
 	{
-		switch (state)
-		{
-			case START:
-				prepareToStart(); // General Method
-				createTeams(ConfigData.getInstance().OVO_COUNT_TEAM);
-				teleportAllPlayers(RADIUS_SPAWN_PLAYER);
-				break;
-				
-			case FIGHT:
-				prepareToFight(); // General Method
-				break;
-				
-			case END:
-				giveRewardsTeams();
-				prepareToEnd(); // General Method
-				break;
-		}
+		createTeams(ConfigData.getInstance().OVO_COUNT_TEAM);
+		teleportAllPlayers(RADIUS_SPAWN_PLAYER);
+	}
+	
+	@Override
+	protected void onEventFight()
+	{
+		// Nothing
+	}
+	
+	@Override
+	protected void onEventEnd()
+	{
+		giveRewardsTeams();
 	}
 	
 	// LISTENERS ------------------------------------------------------
-	@Override
-	public boolean onUseSkill(PlayerHolder ph, L2Character target, Skill skill)
-	{
-		return false;
-	}
-	
-	@Override
-	public boolean onAttack(PlayerHolder ph, L2Character target)
-	{
-		return false;
-	}
-	
 	@Override
 	public void onKill(PlayerHolder ph, L2Character target)
 	{
@@ -148,30 +129,6 @@ public class OneVsOne extends AbstractEvent
 		{
 			EventUtil.messageKill(ph, target);
 		}
-	}
-	
-	@Override
-	public void onDeath(PlayerHolder ph)
-	{
-		//
-	}
-	
-	@Override
-	public boolean onInteract(PlayerHolder ph, L2Npc npc)
-	{
-		return true;
-	}
-	
-	@Override
-	public boolean onUseItem(PlayerHolder ph, L2Item item)
-	{
-		return false;
-	}
-	
-	@Override
-	public void onLogout(PlayerHolder ph)
-	{
-		//
 	}
 	
 	// VARIOUS METHODS -------------------------------------------------
@@ -285,7 +242,7 @@ public class OneVsOne extends AbstractEvent
 				}
 			}
 			
-		} , TIME_BETWEEN_FIGHT * 1000);
+		}, TIME_BETWEEN_FIGHT * 1000);
 	}
 	
 	/**

--- a/java/net/sf/eventengine/events/Survive.java
+++ b/java/net/sf/eventengine/events/Survive.java
@@ -20,19 +20,8 @@ package net.sf.eventengine.events;
 
 import java.util.List;
 
-import com.l2jserver.gameserver.ThreadPoolManager;
-import com.l2jserver.gameserver.enums.Team;
-import com.l2jserver.gameserver.model.actor.L2Character;
-import com.l2jserver.gameserver.model.actor.L2Npc;
-import com.l2jserver.gameserver.model.instancezone.InstanceWorld;
-import com.l2jserver.gameserver.model.items.L2Item;
-import com.l2jserver.gameserver.model.skills.Skill;
-import com.l2jserver.gameserver.network.clientpackets.Say2;
-import com.l2jserver.util.Rnd;
-
 import net.sf.eventengine.datatables.ConfigData;
 import net.sf.eventengine.enums.CollectionTarget;
-import net.sf.eventengine.enums.EventState;
 import net.sf.eventengine.enums.TeamType;
 import net.sf.eventengine.events.handler.AbstractEvent;
 import net.sf.eventengine.events.holders.PlayerHolder;
@@ -40,6 +29,13 @@ import net.sf.eventengine.events.holders.TeamHolder;
 import net.sf.eventengine.events.schedules.AnnounceNearEndEvent;
 import net.sf.eventengine.util.EventUtil;
 import net.sf.eventengine.util.SortUtil;
+
+import com.l2jserver.gameserver.ThreadPoolManager;
+import com.l2jserver.gameserver.enums.Team;
+import com.l2jserver.gameserver.model.actor.L2Character;
+import com.l2jserver.gameserver.model.instancezone.InstanceWorld;
+import com.l2jserver.gameserver.network.clientpackets.Say2;
+import com.l2jserver.util.Rnd;
 
 /**
  * Event survival<br>
@@ -69,33 +65,22 @@ public class Survive extends AbstractEvent
 	}
 	
 	@Override
-	public void runEventState(EventState state)
+	protected void onEventStart()
 	{
-		switch (state)
-		{
-			case START:
-				prepareToStart(); // General Method
-				createTeam(ConfigData.getInstance().SURVIVE_COUNT_TEAM);
-				teleportAllPlayers(RADIUS_SPAWN_PLAYER);
-				break;
-				
-			case FIGHT:
-				prepareToFight(); // General Method
-				spawnsMobs();
-				break;
-				
-			case END:
-				// showResult();
-				giveRewardsTeams();
-				prepareToEnd(); // General Method
-				break;
-		}
+		createTeam(ConfigData.getInstance().SURVIVE_COUNT_TEAM);
+		teleportAllPlayers(RADIUS_SPAWN_PLAYER);
 	}
 	
 	@Override
-	public boolean onInteract(PlayerHolder ph, L2Npc npc)
+	protected void onEventFight()
 	{
-		return true;
+		spawnsMobs();
+	}
+	
+	@Override
+	protected void onEventEnd()
+	{
+		giveRewardsTeams();
 	}
 	
 	@Override
@@ -127,12 +112,6 @@ public class Survive extends AbstractEvent
 	}
 	
 	@Override
-	public void onDeath(PlayerHolder ph)
-	{
-		//
-	}
-	
-	@Override
 	public boolean onAttack(PlayerHolder ph, L2Character target)
 	{
 		if (target.isPlayable())
@@ -140,24 +119,6 @@ public class Survive extends AbstractEvent
 			return true;
 		}
 		return false;
-	}
-	
-	@Override
-	public boolean onUseSkill(PlayerHolder ph, L2Character target, Skill skill)
-	{
-		return false;
-	}
-	
-	@Override
-	public boolean onUseItem(PlayerHolder ph, L2Item item)
-	{
-		return false;
-	}
-	
-	@Override
-	public void onLogout(PlayerHolder ph)
-	{
-		//
 	}
 	
 	// MISC ---------------------------------------------------------------------------------------
@@ -211,7 +172,7 @@ public class Survive extends AbstractEvent
 				// FIXME agregar al sistema de lang
 				EventUtil.sendEventScreenMessage(ph, "Stage " + _stage, 5000);
 			}
-		} , 5000L);
+		}, 5000L);
 		
 	}
 	

--- a/java/net/sf/eventengine/events/TeamVsTeam.java
+++ b/java/net/sf/eventengine/events/TeamVsTeam.java
@@ -20,17 +20,9 @@ package net.sf.eventengine.events;
 
 import java.util.List;
 
-import com.l2jserver.gameserver.model.actor.L2Character;
-import com.l2jserver.gameserver.model.actor.L2Npc;
-import com.l2jserver.gameserver.model.instancezone.InstanceWorld;
-import com.l2jserver.gameserver.model.items.L2Item;
-import com.l2jserver.gameserver.model.skills.Skill;
-import com.l2jserver.gameserver.network.clientpackets.Say2;
-
 import net.sf.eventengine.datatables.ConfigData;
 import net.sf.eventengine.datatables.MessageData;
 import net.sf.eventengine.enums.CollectionTarget;
-import net.sf.eventengine.enums.EventState;
 import net.sf.eventengine.enums.TeamType;
 import net.sf.eventengine.events.handler.AbstractEvent;
 import net.sf.eventengine.events.holders.PlayerHolder;
@@ -38,6 +30,10 @@ import net.sf.eventengine.events.holders.TeamHolder;
 import net.sf.eventengine.events.schedules.AnnounceNearEndEvent;
 import net.sf.eventengine.util.EventUtil;
 import net.sf.eventengine.util.SortUtil;
+
+import com.l2jserver.gameserver.model.actor.L2Character;
+import com.l2jserver.gameserver.model.instancezone.InstanceWorld;
+import com.l2jserver.gameserver.network.clientpackets.Say2;
 
 /**
  * @author fissban
@@ -60,42 +56,26 @@ public class TeamVsTeam extends AbstractEvent
 	}
 	
 	@Override
-	public void runEventState(EventState state)
+	protected void onEventStart()
 	{
-		switch (state)
-		{
-			case START:
-				prepareToStart(); // General Method
-				createTeams(ConfigData.getInstance().TVT_COUNT_TEAM);
-				teleportAllPlayers(RADIUS_SPAWN_PLAYER);
-				break;
-				
-			case FIGHT:
-				prepareToFight(); // General Method
-				showPoint();
-				break;
-				
-			case END:
-				// showResult();
-				giveRewardsTeams();
-				prepareToEnd(); // General Method
-				break;
-		}
+		createTeams(ConfigData.getInstance().TVT_COUNT_TEAM);
+		teleportAllPlayers(RADIUS_SPAWN_PLAYER);
+	}
+	
+	@Override
+	protected void onEventFight()
+	{
+		showPoint();
+	}
+	
+	@Override
+	protected void onEventEnd()
+	{
+		// showResult();
+		giveRewardsTeams();
 	}
 	
 	// LISTENERS ------------------------------------------------------
-	@Override
-	public boolean onUseSkill(PlayerHolder ph, L2Character target, Skill skill)
-	{
-		return false;
-	}
-	
-	@Override
-	public boolean onAttack(PlayerHolder ph, L2Character target)
-	{
-		return false;
-	}
-	
 	@Override
 	public void onKill(PlayerHolder ph, L2Character target)
 	{
@@ -134,24 +114,6 @@ public class TeamVsTeam extends AbstractEvent
 		giveResurrectPlayer(ph, TIME_RES_PLAYER, RADIUS_SPAWN_PLAYER);
 		// Incremented by one the number of deaths Character
 		ph.increaseDeaths();
-	}
-	
-	@Override
-	public boolean onInteract(PlayerHolder ph, L2Npc npc)
-	{
-		return true;
-	}
-	
-	@Override
-	public boolean onUseItem(PlayerHolder ph, L2Item item)
-	{
-		return false;
-	}
-	
-	@Override
-	public void onLogout(PlayerHolder ph)
-	{
-		//
 	}
 	
 	// VARIOUS METHODS -------------------------------------------------


### PR DESCRIPTION
## Summary
- Se eliminó el abstract de los listeners en AbstractEvent debido a que muchos eventos no necesitan implementarlos, ocupando el override espacio innecesario.
- runEventState pasa a ser final e implementa 3 nuevos métodos: onEventStart (abstract), onEventFight y onEventEnd(abstract). onEventFight no es abstracto porque la mayoría de los eventos no necesitan implementarlo. 
- Se movió lógica repetida a AbstractEvent (prepareToStart y prepareToEnd).
