### PR TITLE
Sistema de AntiAfk para los eventos.

### DIFF
--- a/Diff_Server.txt
+++ b/Diff_Server.txt
@@ -316,6 +316,28 @@ index 640e695..8267663 100644
  		// If the item has reuse time and it has not passed.
  		// Message from reuse delay must come from item.
  		final int reuseDelay = item.getReuseDelay();
+diff --git a/L2J_Server/java/com/l2jserver/gameserver/network/clientpackets/ValidatePosition.java b/L2J_Server/java/com/l2jserver/gameserver/network/clientpackets/ValidatePosition.java
+index 95f8805..abc28eb 100644
+--- a/L2J_Server/java/com/l2jserver/gameserver/network/clientpackets/ValidatePosition.java
++++ b/L2J_Server/java/com/l2jserver/gameserver/network/clientpackets/ValidatePosition.java
+@@ -25,6 +25,8 @@
+ import com.l2jserver.gameserver.network.serverpackets.GetOnVehicle;
+ import com.l2jserver.gameserver.network.serverpackets.ValidateLocation;
+ 
++import net.sf.eventengine.EventEngineManager;
++
+ /**
+  * This class ...
+  * @version $Revision: 1.13.4.7 $ $Date: 2005/03/27 15:29:30 $
+@@ -62,6 +64,8 @@
+ 		final int realY = activeChar.getY();
+ 		int realZ = activeChar.getZ();
+ 		
++		EventEngineManager.getInstance().listenerOnMovement(activeChar);
++		
+ 		if (Config.DEVELOPER)
+ 		{
+ 			_log.fine("client pos: " + _x + " " + _y + " " + _z + " head " + _heading);
 diff --git a/L2J_Server/java/com/l2jserver/gameserver/network/serverpackets/AbstractNpcInfo.java b/L2J_Server/java/com/l2jserver/gameserver/network/serverpackets/AbstractNpcInfo.java
 index 1f406be..b1ae84e 100644
 --- a/L2J_Server/java/com/l2jserver/gameserver/network/serverpackets/AbstractNpcInfo.java

--- a/dist/game/config/EventEngine/EventEngine.properties
+++ b/dist/game/config/EventEngine/EventEngine.properties
@@ -66,3 +66,9 @@ EventMaxPlayerLevel = 85
 # Maximum number of buffs you can choose
 # Default 5
 EventMaxBuffCount = 5
+
+# Enabled Anti Afk System
+EventAntiAfkEnabled = True
+
+# Check time for Afk in secs
+EventAntiAfkCheckTime = 30

--- a/java/net/sf/eventengine/EventEngineManager.java
+++ b/java/net/sf/eventengine/EventEngineManager.java
@@ -162,6 +162,25 @@ public class EventEngineManager
 	
 	// XXX LISTENERS -------------------------------------------------------------------------------------
 	/**
+	 * @param player -> personaje
+	 */
+	public void listenerOnMovement(L2PcInstance player)
+	{
+		if (_currentEvent != null)
+		{
+			try
+			{
+				_currentEvent.listenerOnMovement(player);
+			}
+			catch (Exception e)
+			{
+				LOGGER.warning(EventEngineManager.class.getSimpleName() + ": -> listenerOnMovement() " + e);
+				e.printStackTrace();
+			}
+		}
+	}
+	
+	/**
 	 * @param playable -> personaje o summon
 	 * @param target -> NO puede ser null
 	 * @return true -> solo en el caso de que no queremos q un ataque continue su progeso normal.

--- a/java/net/sf/eventengine/datatables/ConfigData.java
+++ b/java/net/sf/eventengine/datatables/ConfigData.java
@@ -58,6 +58,8 @@ public class ConfigData
 	public int MIN_LVL_IN_EVENT;
 	public int MAX_LVL_IN_EVENT;
 	public static int MAX_BUFF_COUNT;
+	public boolean ANTI_AFK_ENABLED;
+	public int AFK_CHECK_TIME;
 	
 	// -------------------------------------------------------------------------------
 	// Configs Capture The Flag
@@ -162,6 +164,8 @@ public class ConfigData
 		MIN_LVL_IN_EVENT = settings.getInt("EventMinPlayerLevel", 40);
 		MAX_LVL_IN_EVENT = settings.getInt("EventMaxPlayerLevel", 78);
 		MAX_BUFF_COUNT = settings.getInt("EventMaxBuffCount", 5);
+		ANTI_AFK_ENABLED = settings.getBoolean("EventAntiAfkEnabled", true);
+		AFK_CHECK_TIME = settings.getInt("EventAntiAfkCheckTime", 30);
 		
 		// ------------------------------------------------------------------------------------- //
 		// CaptureTheFlag.properties

--- a/java/net/sf/eventengine/events/handler/AbstractEvent.java
+++ b/java/net/sf/eventengine/events/handler/AbstractEvent.java
@@ -34,7 +34,6 @@ import com.l2jserver.gameserver.model.actor.instance.L2CubicInstance;
 import com.l2jserver.gameserver.model.actor.instance.L2PcInstance;
 import com.l2jserver.gameserver.model.holders.ItemHolder;
 import com.l2jserver.gameserver.model.holders.SkillHolder;
-import com.l2jserver.gameserver.model.instancezone.InstanceWorld;
 import com.l2jserver.gameserver.model.items.L2Item;
 import com.l2jserver.gameserver.model.skills.Skill;
 import com.l2jserver.gameserver.taskmanager.DecayTaskManager;
@@ -46,6 +45,7 @@ import net.sf.eventengine.datatables.ConfigData;
 import net.sf.eventengine.datatables.MessageData;
 import net.sf.eventengine.enums.EventState;
 import net.sf.eventengine.enums.TeamType;
+import net.sf.eventengine.events.handler.managers.AntiAfkManager;
 import net.sf.eventengine.events.handler.managers.InstanceWorldManager;
 import net.sf.eventengine.events.handler.managers.PlayersManager;
 import net.sf.eventengine.events.handler.managers.ScheduledEventsManager;
@@ -98,6 +98,14 @@ public abstract class AbstractEvent
 	protected abstract void onEventFight();
 	
 	protected abstract void onEventEnd();
+	
+	// XXX ANTI AFK SYSTEM -------------------------------------------------------------------------------
+	private AntiAfkManager _antiAfkManager;
+	
+	public AntiAfkManager getAntiAfkManager()
+	{
+		return _antiAfkManager;
+	}
 	
 	// XXX TEAMS -----------------------------------------------------------------------------------------
 	private TeamsManagers _teamsManagers = new TeamsManagers();
@@ -157,6 +165,34 @@ public abstract class AbstractEvent
 	// LISTENERS ------------------------------------------------------------------------------------ //
 	
 	/**
+	 * @param player
+	 */
+	public void listenerOnMovement(L2PcInstance player)
+	{
+		if (!getPlayerEventManager().isPlayableInEvent(player))
+		{
+			return;
+		}
+		
+		PlayerHolder ph = getPlayerEventManager().getEventPlayer(player);
+		if (getAntiAfkManager() != null)
+		{
+			getAntiAfkManager().addPlayer(ph);
+		}
+		
+		onMovement(ph);
+	}
+	
+	/**
+	 * @param ph
+	 * @param npc
+	 */
+	public void onMovement(PlayerHolder ph)
+	{
+		return;
+	}
+	
+	/**
 	 * Si se retorna "false" no se mostrara ningun html
 	 * @param player
 	 * @param target
@@ -168,7 +204,13 @@ public abstract class AbstractEvent
 			return true;
 		}
 		
-		return onInteract(getPlayerEventManager().getEventPlayer(player), getSpawnManager().getEventNpc(target));
+		PlayerHolder ph = getPlayerEventManager().getEventPlayer(player);
+		if (getAntiAfkManager() != null)
+		{
+			getAntiAfkManager().addPlayer(ph);
+		}
+		
+		return onInteract(ph, getSpawnManager().getEventNpc(target));
 	}
 	
 	/**
@@ -191,6 +233,12 @@ public abstract class AbstractEvent
 			return;
 		}
 		
+		PlayerHolder ph = getPlayerEventManager().getEventPlayer(playable);
+		if (getAntiAfkManager() != null)
+		{
+			getAntiAfkManager().addPlayer(ph);
+		}
+		
 		// ignoramos siempre si matan algun summon.
 		// XXX se podria usar en algun evento...analizar!
 		if (target.isSummon())
@@ -198,7 +246,7 @@ public abstract class AbstractEvent
 			return;
 		}
 		
-		onKill(getPlayerEventManager().getEventPlayer(playable), target);
+		onKill(ph, target);
 	}
 	
 	/**
@@ -240,6 +288,11 @@ public abstract class AbstractEvent
 		
 		// We get the player involved in our event.
 		PlayerHolder activePlayer = getPlayerEventManager().getEventPlayer(playable);
+		
+		if (getAntiAfkManager() != null)
+		{
+			getAntiAfkManager().addPlayer(activePlayer);
+		}
 		
 		// CHECK FRIENDLY_FIRE ----------------------------------------
 		if (ConfigData.getInstance().FRIENDLY_FIRE)
@@ -302,6 +355,11 @@ public abstract class AbstractEvent
 		// We get the player involved in our event.
 		PlayerHolder activePlayer = getPlayerEventManager().getEventPlayer(playable);
 		
+		if (getAntiAfkManager() != null)
+		{
+			getAntiAfkManager().addPlayer(activePlayer);
+		}
+		
 		// CHECK FRIENDLY_FIRE ----------------------------------------
 		if (ConfigData.getInstance().FRIENDLY_FIRE)
 		{
@@ -349,6 +407,12 @@ public abstract class AbstractEvent
 			return false;
 		}
 		
+		PlayerHolder ph = getPlayerEventManager().getEventPlayer(player);
+		if (getAntiAfkManager() != null)
+		{
+			getAntiAfkManager().addPlayer(ph);
+		}
+		
 		// We will not allow the use of pots or scroll.
 		// XXX se podria setear como un config el tema de las pots
 		if (item.isScroll() || item.isPotion())
@@ -356,7 +420,7 @@ public abstract class AbstractEvent
 			return true;
 		}
 		
-		return onUseItem(getPlayerEventManager().getEventPlayer(player), item);
+		return onUseItem(ph, item);
 	}
 	
 	/**
@@ -378,12 +442,13 @@ public abstract class AbstractEvent
 				PlayerHolder ph = getPlayerEventManager().getEventPlayer(player);
 				// listener
 				onLogout(ph);
-				// recover the original color title
-				ph.recoverOriginalColorTitle();
-				// recover the original title
-				ph.recoverOriginalTitle();
-				// we remove the character of the created world
-				InstanceManager.getInstance().getWorld(ph.getDinamicInstanceId()).removeAllowed(ph.getPcInstance().getObjectId());
+				
+				if (getAntiAfkManager() != null)
+				{
+					getAntiAfkManager().addPlayer(ph);
+				}
+				
+				removePlayerFromEvent(ph, true);
 				
 				getPlayerEventManager().getAllEventPlayers().remove(ph);
 			}
@@ -436,39 +501,19 @@ public abstract class AbstractEvent
 	 * <ul>
 	 * <b>Actions: </b>
 	 * </ul>
-	 * <li>Cancel any attack in progress</li><br>
-	 * <li>Cancel any skill in progress</li><br>
-	 * <li>We paralyzed the player</li><br>
-	 * <li>Cancel all character effects</li><br>
-	 * <li>Cancel summon pet</li><br>
-	 * <li>Cancel all character cubics</li><br>
+	 * <li>Cancel any attack in progress</li>
+	 * <li>Cancel any skill in progress</li>
+	 * <li>We paralyzed the player</li>
+	 * <li>Cancel all character effects</li>
+	 * <li>Cancel summon pet</li>
+	 * <li>Cancel all character cubics</li>
 	 */
 	public void prepareToStart()
 	{
 		for (PlayerHolder ph : getPlayerEventManager().getAllEventPlayers())
 		{
-			// Cancel target
-			ph.getPcInstance().setTarget(null);
-			// Cancel any attack in progress
-			ph.getPcInstance().abortAttack();
-			ph.getPcInstance().breakAttack();
-			// Cancel any skill in progress
-			ph.getPcInstance().abortCast();
-			ph.getPcInstance().breakCast();
-			// Cancel all character effects
-			ph.getPcInstance().stopAllEffects();
-			
-			if (ph.getPcInstance().getSummon() != null)
-			{
-				ph.getPcInstance().getSummon().stopAllEffects();
-				ph.getPcInstance().getSummon().unSummon(ph.getPcInstance());
-			}
-			
-			// Cancel all character cubics
-			for (L2CubicInstance cubic : ph.getPcInstance().getCubics().values())
-			{
-				cubic.cancelDisappear();
-			}
+			cancelAllPlayerActions(ph);
+			cancelAllEffects(ph);
 		}
 	}
 	
@@ -477,7 +522,7 @@ public abstract class AbstractEvent
 	 * <ul>
 	 * <b>Actions: </b>
 	 * </ul>
-	 * <li>We canceled the paralysis made in -> <u>prepareToTeleport()</u></li><br>
+	 * <li>We canceled the paralysis made in -> <u>prepareToTeleport()</u></li>
 	 * <li>We deliver buffs defined in configs</li>
 	 */
 	public void prepareToFight()
@@ -493,11 +538,11 @@ public abstract class AbstractEvent
 	 * <ul>
 	 * <b>Actions: </b>
 	 * </ul>
-	 * <li>Cancel any attack in progress</li><br>
-	 * <li>Cancel any skill in progress</li><br>
-	 * <li>Cancel all effects</li><br>
-	 * <li>Recover the title and color of the participants.</li><br>
-	 * <li>We canceled the Team</li><br>
+	 * <li>Cancel any attack in progress</li>
+	 * <li>Cancel any skill in progress</li>
+	 * <li>Cancel all effects</li>
+	 * <li>Recover the title and color of the participants.</li>
+	 * <li>We canceled the Team</li>
 	 * <li>It out of the world we created for the event</li>
 	 */
 	public void prepareToEnd()
@@ -506,24 +551,9 @@ public abstract class AbstractEvent
 		
 		for (PlayerHolder ph : getPlayerEventManager().getAllEventPlayers())
 		{
-			// Cancel target
-			ph.getPcInstance().setTarget(null);
-			// Cancel any attack in progress
-			ph.getPcInstance().abortAttack();
-			ph.getPcInstance().breakAttack();
-			// Cancel any skill in progress<
-			ph.getPcInstance().abortCast();
-			ph.getPcInstance().breakCast();
-			// Cancel all effects
-			ph.getPcInstance().stopAllEffects();
-			// Recover the title and color of the participants.
-			ph.recoverOriginalColorTitle();
-			ph.recoverOriginalTitle();
-			// It out of the world created for the event
-			
-			InstanceWorld world = InstanceManager.getInstance().getPlayerWorld(ph.getPcInstance());
-			world.removeAllowed(ph.getPcInstance().getObjectId());
-			ph.getPcInstance().setInstanceId(0);
+			cancelAllPlayerActions(ph);
+			cancelAllEffects(ph);
+			removePlayerFromEvent(ph, false);
 			
 			revivePlayer(ph);
 			
@@ -538,12 +568,12 @@ public abstract class AbstractEvent
 	 * <ul>
 	 * <b>Actions: </b>
 	 * </ul>
-	 * <li>Generate a pause before executing any action.</li><br>
-	 * <li>Revive the character.</li><br>
-	 * <li>We give you the buff depending on the event in which this.</li><br>
-	 * <li>Teleport the character depending on the event in this.</li><br>
-	 * <li>We do invulnerable for 5 seconds and not allow it to move.</li><br>
-	 * <li>We canceled the invul and let you move</li><br>
+	 * <li>Generate a pause before executing any action.</li>
+	 * <li>Revive the character.</li>
+	 * <li>We give you the buff depending on the event in which this.</li>
+	 * <li>Teleport the character depending on the event in this.</li>
+	 * <li>We do invulnerable for 5 seconds and not allow it to move.</li>
+	 * <li>We canceled the invul and let you move</li>
 	 * @param player
 	 * @param time
 	 * @param radiusTeleport
@@ -574,9 +604,9 @@ public abstract class AbstractEvent
 	 * <ul>
 	 * <b>Actions: </b>
 	 * </ul>
-	 * <li>Cancel the DecayTask.</li><br>
-	 * <li>Revive the character.</li><br>
-	 * <li>Set max cp, hp and mp.</li><br>
+	 * <li>Cancel the DecayTask.</li>
+	 * <li>Revive the character.</li>
+	 * <li>Set max cp, hp and mp.</li>
 	 * @param ph
 	 */
 	protected void revivePlayer(PlayerHolder ph)
@@ -615,6 +645,74 @@ public abstract class AbstractEvent
 		for (ItemHolder reward : items)
 		{
 			ph.getPcInstance().addItem("eventReward", reward.getId(), reward.getCount(), null, true);
+		}
+	}
+	
+	/**
+	 * <ul>
+	 * <b>Actions: </b>
+	 * </ul>
+	 * <li>Cancel target</li>
+	 * <li>Cancel cast</li>
+	 * <li>Cancel attack</li>
+	 * @param ph
+	 */
+	public void cancelAllPlayerActions(PlayerHolder ph)
+	{
+		// Cancel target
+		ph.getPcInstance().setTarget(null);
+		// Cancel any attack in progress
+		ph.getPcInstance().breakAttack();
+		// Cancel any skill in progress
+		ph.getPcInstance().breakCast();
+	}
+	
+	/**
+	 * <ul>
+	 * <b>Actions: </b>
+	 * </ul>
+	 * <li>Stop all effects from player and summon</li>
+	 * @param ph
+	 */
+	public void cancelAllEffects(PlayerHolder ph)
+	{
+		ph.getPcInstance().stopAllEffects();
+		
+		if (ph.getPcInstance().getSummon() != null)
+		{
+			ph.getPcInstance().getSummon().stopAllEffects();
+			ph.getPcInstance().getSummon().unSummon(ph.getPcInstance());
+		}
+		
+		// Cancel all character cubics
+		for (L2CubicInstance cubic : ph.getPcInstance().getCubics().values())
+		{
+			cubic.cancelDisappear();
+		}
+	}
+	
+	/**
+	 * <ul>
+	 * <b>Actions: </b>
+	 * </ul>
+	 * <li>Recover original title</li>
+	 * <li>Recover original color title</li>
+	 * <li>Remove from instance and back from InstanceId 0</li>
+	 * @param ph
+	 */
+	public void removePlayerFromEvent(PlayerHolder ph, boolean forceRemove)
+	{
+		// Recover the title and color of the participants.
+		ph.recoverOriginalColorTitle();
+		ph.recoverOriginalTitle();
+		
+		// It out of the world created for the event
+		InstanceManager.getInstance().getPlayerWorld(ph.getPcInstance()).removeAllowed(ph.getPcInstance().getObjectId());
+		ph.getPcInstance().setInstanceId(0);
+		
+		if (forceRemove)
+		{
+			getPlayerEventManager().getAllEventPlayers().remove(ph);
 		}
 	}
 }

--- a/java/net/sf/eventengine/events/handler/AbstractEvent.java
+++ b/java/net/sf/eventengine/events/handler/AbstractEvent.java
@@ -69,6 +69,8 @@ public abstract class AbstractEvent
 		// We started the clock to control the sequence of internal events of the event.
 		getScheduledEventsManager().startScheduledEvents();
 		getScheduledEventsManager().startTaskControlTime();
+		// init anti afk
+		_antiAfkManager = new AntiAfkManager();
 	}
 	
 	/** Necessary to hadle the event states. */

--- a/java/net/sf/eventengine/events/handler/managers/AntiAfkManager.java
+++ b/java/net/sf/eventengine/events/handler/managers/AntiAfkManager.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2015-2015 L2J EventEngine
+ *
+ * This file is part of L2J EventEngine.
+ *
+ * L2J EventEngine is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * L2J EventEngine is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.sf.eventengine.events.handler.managers;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+
+import com.l2jserver.gameserver.ThreadPoolManager;
+
+import net.sf.eventengine.EventEngineManager;
+import net.sf.eventengine.datatables.ConfigData;
+import net.sf.eventengine.events.handler.AbstractEvent;
+import net.sf.eventengine.events.holders.PlayerHolder;
+
+/**
+ * Simple system to run every x time and controls the actions of the players.<br>
+ * Each you see that a player performs an action that will be added to "_playersAfkCheck".<br>
+ * If the character is not in this list will be sent event.<br>
+ * @author fissban
+ */
+public class AntiAfkManager
+{
+	private final Set<PlayerHolder> _playersAfkCheck = ConcurrentHashMap.newKeySet();
+	
+	private ScheduledFuture<?> _taskAntiAfk;
+	
+	public AntiAfkManager()
+	{
+		//
+	}
+	
+	/**
+	 * Add a character to the list of "excluded" from the next control system
+	 * @param ph
+	 */
+	public void addPlayer(PlayerHolder ph)
+	{
+		if (!_playersAfkCheck.contains(ph))
+		{
+			_playersAfkCheck.add(ph);
+		}
+	}
+	
+	/**
+	 * @param ph
+	 */
+	public void removePlayer(PlayerHolder ph)
+	{
+		if (_playersAfkCheck.contains(ph))
+		{
+			_playersAfkCheck.remove(ph);
+		}
+	}
+	
+	/**
+	 * Start thread responsible for controlling the actions of the players from time to time.
+	 */
+	public void startTask()
+	{
+		_taskAntiAfk = ThreadPoolManager.getInstance().scheduleGeneralAtFixedRate(() ->
+		{
+			AbstractEvent currentEvent = EventEngineManager.getInstance().getCurrentEvent();
+			
+			for (PlayerHolder ph : currentEvent.getPlayerEventManager().getAllEventPlayers())
+			{
+				if (!_playersAfkCheck.contains(ph))
+				{
+					currentEvent.cancelAllEffects(ph);
+					currentEvent.removePlayerFromEvent(ph, true);
+				}
+			}
+			
+			// clear list
+			_playersAfkCheck.clear();
+			
+		} , ConfigData.getInstance().AFK_CHECK_TIME * 1000, ConfigData.getInstance().AFK_CHECK_TIME * 1000);
+	}
+	
+	/**
+	 * Stop the task responsible for controlling the locations of the players.
+	 */
+	public void stopTask()
+	{
+		_taskAntiAfk.cancel(true);
+	}
+}

--- a/java/net/sf/eventengine/events/schedules/ChangeToEndEvent.java
+++ b/java/net/sf/eventengine/events/schedules/ChangeToEndEvent.java
@@ -21,6 +21,7 @@ package net.sf.eventengine.events.schedules;
 import net.sf.eventengine.EventEngineManager;
 import net.sf.eventengine.enums.EventEngineState;
 import net.sf.eventengine.enums.EventState;
+import net.sf.eventengine.events.handler.AbstractEvent;
 import net.sf.eventengine.events.holders.PlayerHolder;
 import net.sf.eventengine.events.schedules.interfaces.EventScheduled;
 import net.sf.eventengine.util.EventUtil;
@@ -28,7 +29,6 @@ import net.sf.eventengine.util.EventUtil;
 /**
  * @author Zephyr
  */
-
 public class ChangeToEndEvent implements EventScheduled
 {
 	int _time;
@@ -47,17 +47,27 @@ public class ChangeToEndEvent implements EventScheduled
 	@Override
 	public void run()
 	{
-		EventEngineManager.getInstance().getCurrentEvent().runEventState(EventState.END);
+		AbstractEvent currentEvent = EventEngineManager.getInstance().getCurrentEvent();
 		
-		// Borramos todos los spawns de npc
-		EventEngineManager.getInstance().getCurrentEvent().getSpawnManager().removeAllEventNpc();
+		// Change event state
+		currentEvent.runEventState(EventState.END);
 		
-		// Enviamos un mensaje especial para los participantes
-		for (PlayerHolder player : EventEngineManager.getInstance().getCurrentEvent().getPlayerEventManager().getAllEventPlayers())
+		// Deletes all the event spawns
+		currentEvent.getSpawnManager().removeAllEventNpc();
+		
+		// Stop antiAfkTask
+		if (currentEvent.getAntiAfkManager() != null)
+		{
+			currentEvent.getAntiAfkManager().stopTask();
+		}
+		
+		// It sends special message for participants
+		for (PlayerHolder player : currentEvent.getPlayerEventManager().getAllEventPlayers())
 		{
 			EventUtil.sendEventSpecialMessage(player, 1, "status_finished");
 		}
 		
+		// Change event engine state
 		EventEngineManager.getInstance().setEventEngineState(EventEngineState.EVENT_ENDED);
 	}
 }

--- a/java/net/sf/eventengine/events/schedules/ChangeToFightEvent.java
+++ b/java/net/sf/eventengine/events/schedules/ChangeToFightEvent.java
@@ -20,6 +20,7 @@ package net.sf.eventengine.events.schedules;
 
 import net.sf.eventengine.EventEngineManager;
 import net.sf.eventengine.enums.EventState;
+import net.sf.eventengine.events.handler.AbstractEvent;
 import net.sf.eventengine.events.holders.PlayerHolder;
 import net.sf.eventengine.events.schedules.interfaces.EventScheduled;
 import net.sf.eventengine.util.EventUtil;
@@ -27,7 +28,6 @@ import net.sf.eventengine.util.EventUtil;
 /**
  * @author Zephyr
  */
-
 public class ChangeToFightEvent implements EventScheduled
 {
 	int _time;
@@ -46,12 +46,21 @@ public class ChangeToFightEvent implements EventScheduled
 	@Override
 	public void run()
 	{
-		EventEngineManager.getInstance().getCurrentEvent().runEventState(EventState.FIGHT);
+		AbstractEvent currentEvent = EventEngineManager.getInstance().getCurrentEvent();
 		
-		// Enviamos un mensaje especial para los participantes
-		for (PlayerHolder player : EventEngineManager.getInstance().getCurrentEvent().getPlayerEventManager().getAllEventPlayers())
+		// Change event state
+		currentEvent.runEventState(EventState.FIGHT);
+		
+		// It sends special message for participants
+		for (PlayerHolder player : currentEvent.getPlayerEventManager().getAllEventPlayers())
 		{
 			EventUtil.sendEventSpecialMessage(player, 2, "status_started");
+		}
+		
+		// Start antiAfk task
+		if (currentEvent.getAntiAfkManager() != null)
+		{
+			currentEvent.getAntiAfkManager().startTask();
 		}
 	}
 }


### PR DESCRIPTION
- Este sistema tine oyentes en todos los listeners para capturar toda
  accion posible de los players, en caso de no encontrar alguna accion es
  removido del evento.
- El task de control inicia en el estado de evento "FIGHT" y termina en
  "END".
- Se crea nuevo listener para capturar el movimiento de los personajes.
  Autor: fissban
  Revision del codigo: luksdlt92
  Idea: Swarlog
