### PR TITLE
Avoid a NPE when you interact with npc that doesn't have NpcHolder

### DIFF
--- a/java/net/sf/eventengine/events/handler/AbstractEvent.java
+++ b/java/net/sf/eventengine/events/handler/AbstractEvent.java
@@ -219,7 +219,7 @@ public abstract class AbstractEvent
 	 */
 	public boolean listenerOnInteract(L2PcInstance player, L2Npc target)
 	{
-		if (!getPlayerEventManager().isPlayableInEvent(player) && !getSpawnManager().isNpcInEvent(target))
+		if (!getPlayerEventManager().isPlayableInEvent(player) || !getSpawnManager().isNpcInEvent(target))
 		{
 			return true;
 		}


### PR DESCRIPTION
## Summary

[ENG] Avoid a NPE when you interact with npc that doesn't have NpcHolder. For example, you could talk with Event Engine Manager when you are waiting to teleport, then the NPE appears.

[ESP] Evita un NPE que sucede cuando interactuas con un NPC que no tiene NpcHolder. Por ejemplo, podrías hablar con el Event Engine Manager cuando estás esperando para ser teletransportado y el NPE aparecería.
