### PR TITLE
Bugfix on interact listener with Global npcs

### DIFF
--- a/java/net/sf/eventengine/EventEngineManager.java
+++ b/java/net/sf/eventengine/EventEngineManager.java
@@ -235,13 +235,13 @@ public class EventEngineManager
 	 * @param player
 	 * @param target
 	 */
-	public boolean listenerOnInteract(L2PcInstance player, L2Npc target)
+	public void listenerOnInteract(L2PcInstance player, L2Npc target)
 	{
 		if (_currentEvent != null)
 		{
 			try
 			{
-				return _currentEvent.listenerOnInteract(player, target);
+				_currentEvent.listenerOnInteract(player, target);
 			}
 			catch (Exception e)
 			{
@@ -249,8 +249,6 @@ public class EventEngineManager
 				e.printStackTrace();
 			}
 		}
-		
-		return true;
 	}
 	
 	/**

--- a/java/net/sf/eventengine/adapter/EventEngineAdapter.java
+++ b/java/net/sf/eventengine/adapter/EventEngineAdapter.java
@@ -8,6 +8,7 @@ import com.l2jserver.gameserver.model.actor.instance.L2PcInstance;
 import com.l2jserver.gameserver.model.events.EventType;
 import com.l2jserver.gameserver.model.events.ListenerRegisterType;
 import com.l2jserver.gameserver.model.events.annotations.Priority;
+import com.l2jserver.gameserver.model.events.annotations.Range;
 import com.l2jserver.gameserver.model.events.annotations.RegisterEvent;
 import com.l2jserver.gameserver.model.events.annotations.RegisterType;
 import com.l2jserver.gameserver.model.events.impl.character.OnCreatureAttack;
@@ -113,7 +114,9 @@ public class EventEngineAdapter extends Quest
 	
 	// When a player talks with npc
 	@RegisterEvent(EventType.ON_NPC_FIRST_TALK)
-	@RegisterType(ListenerRegisterType.GLOBAL_NPCS)
+	@RegisterType(ListenerRegisterType.NPC)
+	// The npc with ids from 36600 to 36699 are reserved for engine
+	@Range(from = 36600, to = 36699)
 	@Priority(Integer.MAX_VALUE)
 	public void onNpcInteract(OnNpcFirstTalk event)
 	{

--- a/java/net/sf/eventengine/events/CaptureTheFlag.java
+++ b/java/net/sf/eventengine/events/CaptureTheFlag.java
@@ -96,30 +96,30 @@ public class CaptureTheFlag extends AbstractEvent
 	}
 	
 	@Override
-	public boolean onInteract(PlayerHolder ph, NpcHolder npcHolder)
+	public void onInteract(PlayerHolder ph, NpcHolder npcHolder)
 	{
 		if (npcHolder.getNpcInstance().getId() == FLAG)
 		{
 			if (hasFlag(ph))
 			{
-				return false;
+				return;
 			}
 			
 			TeamType flagTeam = _flagSpawn.get(npcHolder);
 			
 			if (ph.getTeamType() != flagTeam)
 			{
-				// Animacion
+				// Animation
 				ph.getPcInstance().broadcastPacket(new MagicSkillUse(ph.getPcInstance(), ph.getPcInstance(), 1034, 1, 1, 1));
-				// Borramos del MAP la bandera
+				// Delete the flag from the map
 				_flagSpawn.remove(npcHolder);
-				// Guardamos que personaje lleva determinada bandera
+				// Save the player has the flag
 				_flagHasPlayer.put(ph, flagTeam);
-				// We remove the flag from his position
+				// Remove the flag from its position
 				getSpawnManager().removeNpc(npcHolder);
-				// We equip flag
+				// Equip the flag
 				equipFlag(ph, flagTeam);
-				// We announced that a flag was taken
+				// Announce the flag was taken
 				EventUtil.announceTo(Say2.BATTLEFIELD, "ctf_captured_the_flag", "%holder%", flagTeam.name(), CollectionTarget.ALL_PLAYERS_IN_EVENT);
 			}
 		}
@@ -129,25 +129,23 @@ public class CaptureTheFlag extends AbstractEvent
 			{
 				if (hasFlag(ph))
 				{
-					// Animacion -> Large FireWork
+					// Animation -> Large FireWork
 					ph.getPcInstance().broadcastPacket(new MagicSkillUse(ph.getPcInstance(), ph.getPcInstance(), 2025, 1, 1, 1));
-					// We increased the points
+					// Increase the points
 					getTeamsManager().getPlayerTeam(ph).increasePoints(POINTS_CONQUER_FLAG);
-					// Remove the flag character
+					// Remove the flag from player
 					unequiFlag(ph);
 					
 					TeamHolder th = getTeamsManager().getTeam(_flagHasPlayer.remove(ph));
-					// We created the flag again
+					// Spawn the flag again
 					_flagSpawn.put(getSpawnManager().addEventNpc(FLAG, th.getSpawn().getX(), th.getSpawn().getY(), th.getSpawn().getZ(), 0, Team.NONE, th.getTeamType().name(), false, getInstanceWorldManager().getAllInstancesWorlds().get(0).getInstanceId()), th.getTeamType());
-					// We announced that a flag was taken
+					// Announce the flag was taken
 					EventUtil.announceTo(Say2.BATTLEFIELD, "ctf_conquered_the_flag", "%holder%", th.getTeamType().name(), CollectionTarget.ALL_PLAYERS_IN_EVENT);
-					// Show points of each team
+					// Show team points
 					showPoint();
 				}
 			}
 		}
-		
-		return false;
 	}
 	
 	@Override

--- a/java/net/sf/eventengine/events/handler/AbstractEvent.java
+++ b/java/net/sf/eventengine/events/handler/AbstractEvent.java
@@ -213,15 +213,14 @@ public abstract class AbstractEvent
 	// LISTENERS ------------------------------------------------------------------------------------ //
 	
 	/**
-	 * Si se retorna "false" no se mostrara ningun html
 	 * @param player
 	 * @param target
 	 */
-	public boolean listenerOnInteract(L2PcInstance player, L2Npc target)
+	public void listenerOnInteract(L2PcInstance player, L2Npc target)
 	{
 		if (!getPlayerEventManager().isPlayableInEvent(player) && !getSpawnManager().isNpcInEvent(target))
 		{
-			return true;
+			return;
 		}
 		
 		// Get the player involved in our event.
@@ -233,16 +232,16 @@ public abstract class AbstractEvent
 			getAntiAfkManager().excludePlayer(activePlayer);
 		}
 		
-		return onInteract(activePlayer, getSpawnManager().getEventNpc(target));
+		onInteract(activePlayer, getSpawnManager().getEventNpc(target));
 	}
 	
 	/**
 	 * @param ph
 	 * @param npc
 	 */
-	public boolean onInteract(PlayerHolder ph, NpcHolder npc)
+	public void onInteract(PlayerHolder ph, NpcHolder npc)
 	{
-		return true;
+		// Nothing
 	}
 	
 	/**


### PR DESCRIPTION
## Summary

[ENG]  Bugfix: if you use GLOBAL_NPCS, you override the normal show window from npcs outside events. So, we reserve the ids from 36600 to 36699 to use on Interact (like Manager, Flags and Holder flags).

[ESP] Bugfix: si utilizás GLOBAL_NPCS en el listener on interact, sobreescribís la ventana normal de los npcs fuera del evento. Es así, que reservamos los ids de 36600 a 36699 para utilizar en el on interact (como el Manager, las banderas y los holders).
